### PR TITLE
Option 1: Remove the explicit declaration of the code sign identity

### DIFF
--- a/src/scripts/ios/enableEntitlements.js
+++ b/src/scripts/ios/enableEntitlements.js
@@ -5,7 +5,6 @@
   const compare = require("node-version-compare");
   const IOS_DEPLOYMENT_TARGET = "8.0";
   const COMMENT_KEY = /_comment$/;
-  const CODESIGNIDENTITY = "iPhone Developer";
 
   // entry
   module.exports = {
@@ -41,7 +40,6 @@
 
     for (config in configurations) {
       buildSettings = configurations[config].buildSettings;
-      buildSettings.CODE_SIGN_IDENTITY = `"${CODESIGNIDENTITY}"`;
       buildSettings.CODE_SIGN_ENTITLEMENTS = `"${entitlementsFile}"`;
 
       // if deployment target is less then the required one - increase it


### PR DESCRIPTION
Fix distribution code signing identity in cordova-ios 5.0.1 / cordova 9.0.0 by removing the explicit declaration of the code sign identity in the `enableEntitlements` script

Without this change distribution builds are configured to attempt a build with a debug/developer signing cert: https://github.com/apache/cordova-ios/issues/536#issuecomment-530135917