### PR TITLE
Remove android-prefix from branch-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,6 @@ _Questions? [Contact us](https://support.branch.io/support/tickets/new)_
       <link-domain value="bnc.lt" />  <!-- optional previous link domain -->
       <ios-team-release value="PW4Q8885U7" /> <!-- required if iOS app -->
       <ios-team-debug value="FG35JLLMXX" /> <!-- optional -->
-      <android-prefix value="/WSuf" /> <!-- optional (for bnc.lt link domains) -->
       <android-testmode value="true" /> <!-- optional (simulate installs) -->
     </branch-config>
   ```


### PR DESCRIPTION
As of version 2.7.1 android-prefix is no longer used