### PR TITLE
ISSUE-581 Android Manifest uses-sdk tag optional

### DIFF
--- a/src/scripts/android/updateAndroidManifest.js
+++ b/src/scripts/android/updateAndroidManifest.js
@@ -41,6 +41,7 @@
   function getManifest(context) {
     let pathToManifest;
     let manifest;
+    let targetSdk;
 
     try {
       // cordova platform add android@6.0.0
@@ -71,8 +72,8 @@
     const mainActivityIndex = getMainLaunchActivityIndex(
       manifest.manifest.application[0].activity
     );
-    const targetSdk =
-      manifest.manifest["uses-sdk"][0].$["android:targetSdkVersion"];
+    const usesSdk = manifest.manifest["uses-sdk"];
+    targetSdk = Array.isArray(usesSdk) ? usesSdk[0].$["android:targetSdkVersion"] : undefined;
 
     return {
       file: manifest,


### PR DESCRIPTION
This fixes https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/issues/581 adding an optional uses-sdk tag from Android Manifest file.
This issue is an incompatibility between branch v3.2.0 and cordova-android@8.1.0

Steps to a successful install:

- `ionic start test tutorial --type=ionic-angular`
- cd into test project
- `ionic cordova platform add android` this should add cordova-android@8.1.0
- Add branch-cordova-sdk to config.xml using the following spec `git+https://github.com/adrianyg7/cordova-ionic-phonegap-branch-deep-linking-attribution.git` which is a fork of the v3.2.0 tag including the fix
```
<plugin name="branch-cordova-sdk" spec="git+https://github.com/adrianyg7/cordova-ionic-phonegap-branch-deep-linking-attribution.git" />
<branch-config>
    <branch-key value="key_live_ndqptlgXNE4LHqIahH1WIpbiyFlb62J3" />
    <uri-scheme value="branchcordova" />
    <link-domain value="cordova.app.link" />
    <ios-team-release value="PW4Q8885U7" />
</branch-config>
```
- ionic cordova prepare
- npm i
- ionic cordova run android