### PR TITLE
Sdk 869/resume state not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -53,8 +53,6 @@ public class BranchSDK extends CordovaPlugin {
     private Branch instance;
     private String deepLinkUrl;
 
-    private SessionListener sessionListener;
-
     /**
      * Class Constructor
      */

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -45,7 +45,7 @@ public class BranchSDK extends CordovaPlugin {
     // Standard Debugging Variables
     private static final String LCAT = "CordovaBranchSDK";
     // todo pick up plugin version dynamically
-    private static final String BRANCH_PLUGIN_VERSION = "4.1.2";
+    private static final String BRANCH_PLUGIN_VERSION = "4.1.3";
 
     // Private Method Properties
     private ArrayList<BranchUniversalObjectWrapper> branchObjectWrappers;
@@ -87,8 +87,6 @@ public class BranchSDK extends CordovaPlugin {
     public void onNewIntent(Intent intent) {
         intent.putExtra("branch_force_new_session", true);
         this.activity.setIntent(intent);
-
-        this.reInitSession();
     }
 
     /**
@@ -298,17 +296,7 @@ public class BranchSDK extends CordovaPlugin {
             this.deepLinkUrl = data.toString();
         }
 
-        this.sessionListener = new SessionListener(callbackContext);
-        this.instance.initSession(this.sessionListener, data, activity);
-    }
-
-    private void reInitSession() {
-        if (this.sessionListener == null) {
-            return;
-        }
-
-        this.activity = this.cordova.getActivity();
-        this.instance.reInitSession(this.activity, this.sessionListener);
+        this.instance.initSession(new SessionListener(callbackContext), data, activity);
     }
 
     /**

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -1,6 +1,6 @@
 #import "BranchSDK.h"
 
-NSString * const pluginVersion = @"4.1.2";
+NSString * const pluginVersion = @"4.1.3";
 
 @interface BranchSDK()
 


### PR DESCRIPTION
Both onNewIntent and onResume events get fired when doing intra-app linking, and because we call initSession from onDeviceResume in Cordova, simply setting `intent.putExtra("branch_force_new_session", true);` is enough to force a new session.