### PR TITLE
fix build ios project name

### DIFF
--- a/src/scripts/ios/updateAssociatedDomains.js
+++ b/src/scripts/ios/updateAssociatedDomains.js
@@ -34,11 +34,12 @@
 
     for (let i = 0; i < BUILD_TYPES.length; i++) {
       const buildType = BUILD_TYPES[i];
+      const projectName = preferences.projectName.replace( /[\r\n]+/gm, '' ).replace(/(^[\s]+|[\s]+$)/g, '');
       const plist = path.join(
         preferences.projectRoot,
         "platforms",
         "ios",
-        preferences.projectName,
+        projectName,
         `Entitlements-${buildType}.plist`
       );
       files.push(plist);

--- a/src/scripts/ios/updatePlist.js
+++ b/src/scripts/ios/updatePlist.js
@@ -12,9 +12,8 @@
 
   // updates the platforms/ios/app.plist file with branch settings within app/config.xml
   function addBranchSettings(preferences) {
-    const filePath = `platforms/ios/${preferences.projectName}/${
-      preferences.projectName
-    }-Info.plist`;
+  	const projectName = preferences.projectName.replace( /[\r\n]+/gm, '' ).replace(/(^[\s]+|[\s]+$)/g, '');
+  	const filePath = `platforms/ios/${projectName}/${projectName}-Info.plist`;
     let xml = readPlist(filePath);
     let obj = convertXmlToObject(xml);
 


### PR DESCRIPTION
There is an error building the project in ios.
the cause is that if in the config.xml the project name tag is placed like this.
![image](https://user-images.githubusercontent.com/12752959/76320688-64ecd000-62b7-11ea-9a18-b21f2e02071c.png)
the following error is generated
![image](https://user-images.githubusercontent.com/12752959/76321303-37545680-62b8-11ea-9989-7d6b49b58076.png)
This is due to the characters new line \ n, return \ r and spaces before and after the project name.
Partial solution: not use these characters in the name del projecto.
Definitive solution with regular expressions: replace (/ [\ r \ n] + / gm, '') .replace (/ (^ [\ s] + | [\ s] + $) / g, '')