### PR TITLE
Cordova Feature Requests - iOS Session Override + Platform-specific Domains - SDK-593

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ const standardEvent = {
 var Branch = function Branch() {
   this.debugMode = false;
   this.trackingDisabled = false;
+  this.sessionInitialized = false;
 };
 
 // JavsSript to SDK wrappers
@@ -85,7 +86,15 @@ Branch.prototype.disableTracking = function disableTracking(isEnabled) {
   return execute("disableTracking", [value]);
 };
 
+Branch.prototype.enableTestMode = function initSession() {
+  if (this.sessionInitialized) {
+    return executeReject("[enableTestMode] should be called before [initSession]");
+  }
+  return execute("enableTestMode");
+};
+
 Branch.prototype.initSession = function initSession() {
+  this.sessionInitialized = true;
   return execute("initSession");
 };
 

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -26,6 +26,7 @@
 @property (strong, nonatomic) NSMutableArray *branchUniversalObjArray;
 
 // BranchSDK Basic Methods
+- (void)enableTestMode:(CDVInvokedUrlCommand*)command;
 - (void)initSession:(CDVInvokedUrlCommand*)command;
 - (void)disableTracking:(CDVInvokedUrlCommand*)command;
 - (void)setDebug:(CDVInvokedUrlCommand*)command;

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -58,6 +58,15 @@ NSString * const pluginVersion = @"4.1.3";
   return [NSNumber numberWithBool:[[Branch getInstance] handleDeepLink:url]];
 }
 
+- (id)handleDeepLinkWithNewSession:(CDVInvokedUrlCommand*)command
+{
+  NSString *arg = [command.arguments objectAtIndex:0];
+  NSURL *url = [NSURL URLWithString:arg];
+  self.deepLinkUrl = [url absoluteString];
+
+  return [NSNumber numberWithBool:[[Branch getInstance] handleDeepLinkWithNewSession:url]];
+}
+
 - (void)continueUserActivity:(CDVInvokedUrlCommand*)command
 {
 

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -86,6 +86,11 @@ NSString * const pluginVersion = @"4.1.3";
 #pragma mark - Public APIs
 #pragma mark - Branch Basic Methods
 
+- (void)enableTestMode:(CDVInvokedUrlCommand*)command
+{
+  [Branch setUseTestBranchKey:TRUE];
+}
+
 - (void)initSession:(CDVInvokedUrlCommand*)command
 {
   [[Branch getInstance] registerPluginName:@"CordovaIonic" version:pluginVersion];

--- a/src/scripts/android/updateAndroidManifest.js
+++ b/src/scripts/android/updateAndroidManifest.js
@@ -87,8 +87,13 @@
     const keys = ["io.branch.sdk.BranchKey", "io.branch.sdk.TestMode"];
     const vals = [
       preferences.branchKey,
-      preferences.androidTestMode || "false"
+      preferences.branchTestMode || preferences.androidTestMode || "false"
     ];
+
+    if (preferences.branchKeyTest) {
+      keys.push("io.branch.sdk.BranchKey.test");
+      vals.push(preferences.branchKeyTest);
+    }
 
     // remove old
     for (var i = 0; i < keys.length; i++) {

--- a/src/scripts/android/updateAndroidManifest.js
+++ b/src/scripts/android/updateAndroidManifest.js
@@ -248,7 +248,7 @@
   // determine the Branch link domain <data> to append to the App Link intent filter
   function getAppLinkIntentFilterData(preferences) {
     const intentFilterData = [];
-    const linkDomains = preferences.linkDomain;
+    const linkDomains = [...preferences.androidLinkDomain, ...preferences.linkDomain];
 
     for (let i = 0; i < linkDomains.length; i++) {
       const linkDomain = linkDomains[i];

--- a/src/scripts/ios/updateAssociatedDomains.js
+++ b/src/scripts/ios/updateAssociatedDomains.js
@@ -91,7 +91,7 @@
   // removed previous associated domains related to Branch (will not remove link domain changes from custom domains or custom sub domains)
   function removePreviousAssociatedDomains(preferences, domains) {
     const output = [];
-    const linkDomains = preferences.linkDomain;
+    const linkDomains = [...preferences.iosLinkDomain, ...preferences.linkDomain];
 
     if (!domains) return output;
     for (let i = 0; i < domains.length; i++) {
@@ -122,7 +122,7 @@
   function updateAssociatedDomains(preferences) {
     const domainList = [];
     const prefix = "applinks:";
-    const linkDomains = preferences.linkDomain;
+    const linkDomains = [...preferences.iosLinkDomain, ...preferences.linkDomain];
 
     for (let i = 0; i < linkDomains.length; i++) {
       const linkDomain = linkDomains[i];

--- a/src/scripts/ios/updatePlist.js
+++ b/src/scripts/ios/updatePlist.js
@@ -61,6 +61,8 @@
       CFBundleURLName: SDK,
       CFBundleURLSchemes: [preferences.uriScheme]
     };
+    // ios specific domain will be preferred
+    const linkDomains = [...preferences.iosLinkDomain, ...preferences.linkDomain];
 
     if (!obj.hasOwnProperty("CFBundleURLTypes")) {
       // add
@@ -89,7 +91,7 @@
 
     // override
     obj.branch_key = preferences.branchKey;
-    obj.branch_app_domain = preferences.linkDomain[0];
+    obj.branch_app_domain = linkDomains[0];
 
     return obj;
   }

--- a/src/scripts/ios/updatePlist.js
+++ b/src/scripts/ios/updatePlist.js
@@ -90,7 +90,15 @@
     }
 
     // override
-    obj.branch_key = preferences.branchKey;
+    if (preferences.branchKeyTest) {
+      obj.branch_key = {
+        live: preferences.branchKey,
+        test: preferences.branchKeyTest
+      };
+    } else {
+      obj.branch_key = preferences.branchKey;
+    }
+    
     obj.branch_app_domain = linkDomains[0];
 
     return obj;

--- a/src/scripts/npm/processConfigXml.js
+++ b/src/scripts/npm/processConfigXml.js
@@ -59,6 +59,8 @@
       projectName: getProjectName(configXml),
       branchKey: getBranchValue(branchXml, "branch-key"),
       linkDomain: getBranchLinkDomains(branchXml, "link-domain"),
+      androidLinkDomain: getBranchLinkDomains(branchXml, "android-link-domain"),
+      iosLinkDomain: getBranchLinkDomains(branchXml, "ios-link-domain"),
       uriScheme: getBranchValue(branchXml, "uri-scheme"),
       iosBundleId: getBundleId(configXml, "ios"),
       iosProjectModule: getProjectModule(context),
@@ -97,7 +99,8 @@
     return branchXml.hasOwnProperty(key) ? branchXml[key][0].$.value : null;
   }
 
-  // read branch value from <branch-config> for multiple <link-domain>
+  // read branch value from <branch-config>
+  // for multiple <link-domain>, <android-link-domain> or <ios-link-domain>
   function getBranchLinkDomains(branchXml, key) {
     const output = [];
     if (branchXml.hasOwnProperty(key)) {
@@ -218,9 +221,8 @@
       );
     }
     if (
-      preferences.linkDomain === null ||
       !/^(?!.*?www).*([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+.*)$/.test(
-        preferences.linkDomain
+        [...preferences.linkDomain, ...preferences.androidLinkDomain, preferences.iosLinkDomain]
       )
     ) {
       throw new Error(

--- a/src/scripts/npm/processConfigXml.js
+++ b/src/scripts/npm/processConfigXml.js
@@ -57,7 +57,9 @@
     return {
       projectRoot: getProjectRoot(context),
       projectName: getProjectName(configXml),
-      branchKey: getBranchValue(branchXml, "branch-key"),
+      branchKey: getBranchKey(branchXml, "branch-key-live"),
+      branchKeyTest: getBranchValue(branchXml, "branch-key-test"),
+      branchTestMode: getBranchValue(branchXml, "branch-test-mode"),
       linkDomain: getBranchLinkDomains(branchXml, "link-domain"),
       androidLinkDomain: getBranchLinkDomains(branchXml, "android-link-domain"),
       iosLinkDomain: getBranchLinkDomains(branchXml, "ios-link-domain"),
@@ -68,7 +70,7 @@
       iosTeamDebug: getBranchValue(branchXml, "ios-team-debug"), // optional
       androidBundleId: getBundleId(configXml, "android"), // optional
       androidPrefix: getBranchValue(branchXml, "android-prefix"), // optional
-      androidTestMode: getBranchValue(branchXml, "android-testmode") // optional
+      androidTestMode: getBranchValue(branchXml, "android-testmode") // DEPRECATED optional
     };
   }
 
@@ -97,6 +99,12 @@
   // read branch value from <branch-config>
   function getBranchValue(branchXml, key) {
     return branchXml.hasOwnProperty(key) ? branchXml[key][0].$.value : null;
+  }
+
+  // read branch value from (<branch-key> DEPRECATED)
+  // or <branch-key-live>
+  function getBranchKey(branchXml) {
+    return getBranchValue(branchXml, "branch-key-live") || getBranchValue(branchXml, "branch-key");
   }
 
   // read branch value from <branch-config>
@@ -207,9 +215,14 @@
         'BRANCH SDK: Invalid "name" in your config.xml. Docs https://goo.gl/GijGKP'
       );
     }
-    if (preferences.branchKey === null) {
+    if (preferences.branchKey === null && preferences.branchKeyLive === null) {
       throw new Error(
-        'BRANCH SDK: Invalid "branch-key" in <branch-config> in your config.xml. Docs https://goo.gl/GijGKP'
+        'BRANCH SDK: Invalid "branch-key-live" in <branch-config> in your config.xml. Docs https://goo.gl/GijGKP'
+      );
+    }
+    if (preferences.branchKey === null && preferences.branchKeyTest === null) {
+      throw new Error(
+        'BRANCH SDK: Invalid "branch-key-test" in <branch-config> in your config.xml. Docs https://goo.gl/GijGKP'
       );
     }
     if (
@@ -278,6 +291,17 @@
     ) {
       throw new Error(
         'BRANCH SDK: Invalid "android-testmode" in <branch-config> in your config.xml. Docs https://goo.gl/GijGKP'
+      );
+    }
+    if (
+      !(
+        preferences.branchTestMode === "true" ||
+        preferences.branchTestMode === "false" ||
+        preferences.branchTestMode === null
+      )
+    ) {
+      throw new Error(
+        'BRANCH SDK: Invalid "branch-test-mode" in <branch-config> in your config.xml. Docs https://goo.gl/GijGKP'
       );
     }
   }


### PR DESCRIPTION
1. Add a wrapper function for the iOS session restart function to enable handling a Branch link from within the app

2. Enable the ability to add platform-specific domains. Allow to add platform-specific domains by using a <android link-domain> or <ios link-domain> tags

3. Replace <branch-key> tag in config.xml with <branch-key-live>, <branch-key-test>, and a boolean <branch-test-mode>.