### PR TITLE
Add branch header search paths to cocoapods config

### DIFF
--- a/src/scripts/hooks/beforePrepare.js
+++ b/src/scripts/hooks/beforePrepare.js
@@ -4,6 +4,7 @@
   const configPreferences = require("../npm/processConfigXml.js");
   const iosPlist = require("../ios/updatePlist.js");
   const iosAssociatedDomains = require("../ios/updateAssociatedDomains.js");
+  const iosHeaderPaths = require("../ios/updateHeaderPaths.js");
   const IOS = "ios";
 
   // entry
@@ -18,6 +19,7 @@
       if (platform === IOS) {
         iosPlist.addBranchSettings(preferences);
         iosAssociatedDomains.addAssociatedDomains(preferences);
+        iosHeaderPaths.addHeaderPaths();
       }
     });
   }

--- a/src/scripts/ios/updateHeaderPaths.js
+++ b/src/scripts/ios/updateHeaderPaths.js
@@ -1,0 +1,42 @@
+(function() {
+  // properties
+
+  const fs = require("fs");
+
+  // entry
+  module.exports = {
+    addHeaderPaths: addHeaderPaths
+  };
+
+  // updates the platforms/ios/cordova/build.xcconfig file with Branch's Header Paths
+  // some plugins still use the old CocoaPods way to resolve config dirs or other obscure
+  // ways that modify CocoaPods config. That causes the Branch plugin to fail on iOS build.
+  function addHeaderPaths() {
+    const filePath = "platforms/ios/cordova/build.xcconfig";
+    let config = readBuildXcconfig(filePath);
+
+    config = updateHeaderPaths(config);
+    writeBuildXcconfig(filePath, config);
+  }
+
+  // update build.xcconfig with Branch's Header Paths
+  function updateHeaderPaths(config) {
+    config = config.split("\n")
+      .map(function (line) {
+        if (line.indexOf("HEADER_SEARCH_PATHS") > -1 && line.indexOf("Branch-SDK") === -1) {
+          line += ' "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK" "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK/Networking" "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK/Networking/Requests"';
+        }
+        return line;
+      });
+
+    return config.join("\n");
+  }
+
+  function readBuildXcconfig(filePath) {
+    return fs.readFileSync(filePath, "utf8");
+  }
+
+  function writeBuildXcconfig(filePath, config) {
+    return fs.writeFileSync(filePath, config, { encoding: "utf8" });
+  }
+})();


### PR DESCRIPTION
Some plugins still use the old CocoaPods way to resolve config dirs or other obscure ways that modify CocoaPods config. That causes the Branch plugin to fail on iOS build.

Solution:
Create a hook that adds some extra config to CocoaPods and avoid being affected by other plugins overriding CocoaPods config.
