### PR TITLE
Update header search paths to match new iOS folder structure

### DIFF
--- a/src/scripts/ios/updateHeaderPaths.js
+++ b/src/scripts/ios/updateHeaderPaths.js
@@ -24,7 +24,7 @@
     config = config.split("\n")
       .map(function (line) {
         if (line.indexOf("HEADER_SEARCH_PATHS") > -1 && line.indexOf("Branch-SDK") === -1) {
-          line += ' "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK" "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK/Networking" "${PODS_ROOT}/Branch/Branch-SDK/Branch-SDK/Networking/Requests"';
+          line += ' "${PODS_ROOT}/Branch/Branch-SDK"';
         }
         return line;
       });


### PR DESCRIPTION
Native iOS SDK 0.35.0 has a new folder structure consisting of a flat folder `Branch/Branch-SDK `
This PR uses the new Path to include a HEADER_SEARCH_PATHS entry in case the default CocoaPods config is changed by other plugin(s).

Related issues:
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/issues/642
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/issues/662
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/issues/602