### PR TITLE
feat(ios): add IntercomUniversalLinkDomains to plist

### DIFF
--- a/src/scripts/ios/updatePlist.js
+++ b/src/scripts/ios/updatePlist.js
@@ -101,6 +101,7 @@
     
     obj.branch_app_domain = linkDomains[0];
 
+    obj.IntercomUniversalLinkDomains = preferences.linkDomain;
     return obj;
   }
 


### PR DESCRIPTION
add IntercomUniversalLinkDomains to plist for compatibility with intercom iOS SDK v9.3+

https://developers.intercom.com/installing-intercom/docs/ios-deep-linking
