### PR TITLE
Fix setLogging to enable logging in native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-5.2.1 December 14, 2022
+5.2.1 Jan 4, 2023
 * Fix Javascript method setLogging to enable logging in the native layer.
 * Update Android SDK to 5.2.7
 * Update iOS SDK to 1.45.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 5.2.1 December 14, 2022
 * Fix Javascript method setLogging to enable logging in the native layer.
 * Update Android SDK to 5.2.7
-* Update iOS SDK to 1.45.1
+* Update iOS SDK to 1.45.2
 
 5.2.0 August 8th, 2022
 * Update iOS SDK to 1.43.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+5.2.1 December 14, 2022
+* Fix Javascript method setLogging to enable logging in the native layer.
+* Update Android SDK to 5.2.7
+* Update iOS SDK to 1.45.1
+
 5.2.0 August 8th, 2022
 * Update iOS SDK to 1.43.1
 * Update Android SDK to 5.2.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="Branch" spec="~> 1.45.1" />
+              <pod name="Branch" spec="~> 1.45.2" />
           </pods>
       </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ SOFTWARE.
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="branch-cordova-sdk"
-  version="5.1.0">
+  version="5.2.1">
 
   <!-- Description -->
   <name>branch-cordova-sdk</name>
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- Manifest configuration is done via a js script.  We should move it to this config in the future. -->
 
     <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-    <framework src="io.branch.sdk.android:library:5.2.0"/>
+    <framework src="io.branch.sdk.android:library:5.2.7"/>
   </platform>
 
   <!-- iOS -->
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="Branch" spec="~> 1.43.1" />
+              <pod name="Branch" spec="~> 1.45.1" />
           </pods>
       </podspec>
   </platform>

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -119,7 +119,7 @@ public class BranchSDK extends CordovaPlugin {
 
         Runnable r = new RunnableThread(action, args, callbackContext);
 
-        if (action.equals("setLogging")) {
+        if (action.equals("enableLogging")) {
             cordova.getActivity().runOnUiThread(r);
             return true;
         } else if (action.equals("setCookieBasedMatching")) {
@@ -607,7 +607,7 @@ public class BranchSDK extends CordovaPlugin {
      * @param isEnable        A {@link Boolean} value to enable/disable logging
      * @param callbackContext A callback to execute at the end of this method
      */
-    private void setLogging(boolean isEnable, CallbackContext callbackContext) {
+    private void enableLogging(boolean isEnable, CallbackContext callbackContext) {
         this.activity = this.cordova.getActivity();
         if (isEnable == true) {
             Branch.enableLogging();
@@ -1233,8 +1233,8 @@ public class BranchSDK extends CordovaPlugin {
             try {
                 Log.d(LCAT, "Runnable: " + this.action);
 
-                if (this.action.equals("setLogging")) {
-                    setLogging(this.args.getBoolean(0), this.callbackContext);
+                if (this.action.equals("enableLogging")) {
+                    enableLogging(this.args.getBoolean(0), this.callbackContext);
                 } else if (this.action.equals("setCookieBasedMatching")) {
                     setCookieBasedMatching(this.args.getString(0), this.callbackContext);
                 } else if (this.action.equals("disableTracking")) {


### PR DESCRIPTION
## Reference
QSS-265 --Unable to receive proper response from SDK to read the logs while creating deep link for Cordova

## Summary
When the JS Branch.setLogging is called, it is defined to send the command “enableLogging” to the native plugin layer: https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/blob/master/src/index.js#L128

However, the native plugin layer is expecting the command “setLogging”
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/blob/master/src/android/io/branch/BranchSDK.java#L122
https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/blob/master/src/android/io/branch/BranchSDK.java#L1236

This PR changes the value of the string to match what's being sent from the JS layer, as well as a minor renaming to the internal method to match. The public API name remains the same.  

## Motivation
This was raised during automation development. This is needed to unblock the usage of `setLogging` in the JS layer of the plugin.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Checkout, build with local package, see logs in native layer without calling Branch.enableLogging in java code.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
