### PR TITLE
feat(initSessionWithCallback): keep callback alive for repeat deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+* Added initSessionWithCallback(onSuccess, onFail) - like initSession(), but keeps the native
+  callback alive (keepCallback) so Branch links opened while the app is already running
+  (Android onNewIntent -> reInit) are also delivered, not just the first one.
+
 6.6.1 March 3, 2026
 * Bug fix: Removed didFinishLaunchingWithOptions() from AppDelegate+BranchSDK.m
 

--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,14 @@ Branch.prototype.initSession = function initSession() {
   return execute("initSession");
 };
 
+Branch.prototype.initSessionWithCallback = function initSession(onSuccess, onFail) {
+  this.sessionInitialized = true;
+  if (!onSuccess || typeof onSuccess !== "function") {
+    return executeReject("Please set onSuccess callback");
+  }
+  return executeCallback("initSession", onSuccess, [true]);
+};
+
 Branch.prototype.setRequestMetadata = function setRequestMetadata(key, val) {
   if (!key || typeof key !== "string") {
     return executeReject("Please set key");

--- a/src/index.js
+++ b/src/index.js
@@ -65,13 +65,17 @@ function execute(method, params) {
   });
 }
 
-function executeCallback(method, callback, params) {
+function executeCallback(method, callback, params, onFail) {
   var output = !params ? [] : params;
 
   exec(
     callback,
     function failure(err) {
-      console.error(err);
+      if (typeof onFail === "function") {
+        onFail(err);
+      } else {
+        console.error(err);
+      }
     },
     API_CLASS,
     method,
@@ -106,12 +110,14 @@ Branch.prototype.initSession = function initSession() {
   return execute("initSession");
 };
 
-Branch.prototype.initSessionWithCallback = function initSession(onSuccess, onFail) {
+// keepCallback keeps the native success handler alive so links opened while the app is
+// already running (Android onNewIntent -> reInit) are delivered too, not just the first one.
+Branch.prototype.initSessionWithCallback = function initSessionWithCallback(onSuccess, onFail) {
   this.sessionInitialized = true;
   if (!onSuccess || typeof onSuccess !== "function") {
     return executeReject("Please set onSuccess callback");
   }
-  return executeCallback("initSession", onSuccess, [true]);
+  return executeCallback("initSession", onSuccess, [true], onFail);
 };
 
 Branch.prototype.setRequestMetadata = function setRequestMetadata(key, val) {

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -98,6 +98,7 @@ NSString * const pluginVersion = @"6.6.1";
 
     NSString *resultString = nil;
     CDVPluginResult *pluginResult = nil;
+    bool enableCallBack = [[command.arguments objectAtIndex:0] boolValue];
 
     if (!error) {
       if (params != nil && [params count] > 0) {
@@ -130,6 +131,9 @@ NSString * const pluginVersion = @"6.6.1";
     }
 
     if (command != nil) {
+      if(enableCallBack){
+        [pluginResult setKeepCallbackAsBool:YES];
+      }
       [self.commandDelegate sendPluginResult: pluginResult callbackId: command.callbackId];
     }
   }];

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -98,7 +98,7 @@ NSString * const pluginVersion = @"6.6.1";
 
     NSString *resultString = nil;
     CDVPluginResult *pluginResult = nil;
-    bool enableCallBack = [[command.arguments objectAtIndex:0] boolValue];
+    bool enableCallBack = command.arguments.count > 0 && [[command.arguments objectAtIndex:0] boolValue];
 
     if (!error) {
       if (params != nil && [params count] > 0) {


### PR DESCRIPTION

**awesome-cordova-plugins**
https://github.com/danielsogl/awesome-cordova-plugins/pull/3660

## Reference

This re-opens #686, which sat without review for ~2 years and went stale. The
TypeScript typings for this exact method (`initSessionWithCallback(): Observable<...>`,
using awesome-cordova-plugins' `{ observable: true }` decorator) were already merged
into `awesome-cordova-plugins` back in 2021 (linked above) and have had no native
implementation to back them since.

## Summary

Adds `initSessionWithCallback(onSuccess, onFail)`: same as `initSession()`, but keeps
the native success callback alive (`keepCallback`) instead of resolving/releasing it
after the first result.

## Motivation

`initSession()` only ever fires its callback once. That's fine for a cold start, but
if the app is already running and the user opens another Branch link (Android
`onNewIntent`), there's currently no way for JS to be notified of the new deep link
data - the original callback is already gone.

This PR:
- Stores the `BranchReferralInitListener` on Android so `onNewIntent` can re-trigger
  it via `reInit()` instead of only updating the intent.
- Adds an opt-in `keepCallback` flag (`PluginResult.setKeepCallback` / iOS
  `setKeepCallbackAsBool:`) so the JS callback keeps receiving results across
  multiple deep link opens, instead of firing once and being torn down.

For context: Branch's own Capacitor plugin (`capacitor-branch-deep-links`) solves the
same underlying problem - continuous session-init delivery, not a one-shot result -
via `addListener('init', cb)` / `addListener('initError', cb)`. This PR keeps the
existing Cordova plugin's callback-based style (matching the typings already merged
into awesome-cordova-plugins) rather than introducing a new listener API.

Also included, on top of the original #686 diff:
- iOS: `initSession` read `command.arguments[0]` unconditionally, which throws
  `NSRangeException` (crash) when `initSession()` is called without the keepCallback
  arg - the existing non-callback call site never passes it. Now guarded with a
  bounds check, mirroring the Android side which already did
  `args.length() != 0 && args.getBoolean(0)`.
- JS: `onFail` was accepted by `initSessionWithCallback` but never wired into the
  native error callback, so init errors were silently swallowed (`console.error`)
  instead of reaching the caller.
- JS: the named function expression for `initSessionWithCallback` still read
  `initSession` (copy-paste), fixed for correct stack traces.
- Rebased onto current `master` and added a CHANGELOG entry.

## Type Of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions

1. Call `branch.initSessionWithCallback(onSuccess, onFail)` instead of `initSession()`
   on app start.
2. Cold start the app via a Branch link - `onSuccess` fires once with the referring
   params, same as `initSession()` today.
3. With the app still running (not killed), open a second Branch link (e.g. via
   `adb shell am start -a android.intent.action.VIEW -d "<branch-link>"` on Android,
   or re-tapping a link on iOS) - `onSuccess` fires again with the new link's params,
   without needing to call `initSession()`/`initSessionWithCallback()` again.
4. Call plain `initSession()` (no keepCallback arg) on iOS to confirm it no longer
   crashes (regression check for the arg-bounds fix above).

cc @BranchMetrics/saas-sdk-devs for visibility.
