### PR TITLE
[SDK-2058] Remove v1/event code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "5.2.1",
+  "version": "5.2.1-alpha.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "5.2.1-alpha.0",
+  "version": "5.2.1",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -62,11 +62,6 @@ exports.defineAutoTests = function() {
         "function"
       );
     });
-    it("should contain a method called userCompletedAction()", function() {
-      expect(window.Branch.userCompletedAction).toBeDefined();
-      expect(_typeof(window.Branch.userCompletedAction)).toBe("function");
-    });
-
   });
 
   describe("Branch.getLatestReferringParams()", function() {
@@ -189,23 +184,6 @@ exports.defineAutoTests = function() {
           });
       },
       5000
-    );
-  });
-
-  describe("Branch.userCompletedAction()", function() {
-    beforeEach(function(done) {
-      initSession().then(function() {
-        done();
-      });
-    }, 3000);
-    it(
-      "should successfully execute the method",
-      function(done) {
-        window.Branch.userCompletedAction("login");
-        expect("Success").toBe("Success");
-        done();
-      },
-      10000
     );
   });
 };

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -139,13 +139,6 @@ public class BranchSDK extends CordovaPlugin {
                 if (action.equals("setIdentity")) {
                     cordova.getActivity().runOnUiThread(r);
                     return true;
-                } else if (action.equals("userCompletedAction")) {
-                    if (args.length() < 1 && args.length() > 2) {
-                        callbackContext.error(String.format("Parameter count mismatch"));
-                        return false;
-                    }
-                    cordova.getActivity().runOnUiThread(r);
-                    return true;
                 } else if (action.equals("sendBranchEvent")) {
                     if (args.length() < 1 && args.length() > 2) {
                         callbackContext.error(String.format("Parameter count mismatch"));
@@ -655,40 +648,6 @@ public class BranchSDK extends CordovaPlugin {
     private void setRequestMetadata(String key, String val, CallbackContext callbackContext) {
 
         Branch.getInstance().setRequestMetadata(key, val);
-
-        callbackContext.success("Success");
-
-    }
-
-    /**
-     * <p>A void call to indicate that the user has performed a specific action and for that to be
-     * reported to the Branch API.</p>
-     *
-     * @param action          A {@link String} value to be passed as an action that the user has carried out.
-     *                        For example "logged in" or "registered".
-     * @param callbackContext A callback to execute at the end of this method
-     */
-    private void userCompletedAction(String action, CallbackContext callbackContext) {
-
-        this.instance.userCompletedAction(action);
-
-        callbackContext.success("Success");
-
-    }
-
-    /**
-     * <p>A void call to indicate that the user has performed a specific action and for that to be
-     * reported to the Branch API.</p>
-     *
-     * @param action          A {@link String} value to be passed as an action that the user has carried
-     *                        out. For example "logged in" or "registered".
-     * @param metaData        A {@link JSONObject} containing app-defined meta-data to be attached to a
-     *                        user action that has just been completed.
-     * @param callbackContext A callback to execute at the end of this method
-     */
-    private void userCompletedAction(String action, JSONObject metaData, CallbackContext callbackContext) {
-
-        this.instance.userCompletedAction(action, metaData);
 
         callbackContext.success("Success");
 
@@ -1246,12 +1205,6 @@ public class BranchSDK extends CordovaPlugin {
                 } else {
                     if (this.action.equals("setIdentity")) {
                         setIdentity(this.args.getString(0), this.callbackContext);
-                    } else if (this.action.equals("userCompletedAction")) {
-                        if (this.args.length() == 2) {
-                            userCompletedAction(this.args.getString(0), this.args.getJSONObject(1), this.callbackContext);
-                        } else if (this.args.length() == 1) {
-                            userCompletedAction(this.args.getString(0), this.callbackContext);
-                        }
                     } else if (this.action.equals("sendBranchEvent")) {
                         if (this.args.length() == 2) {
                             sendBranchEvent(this.args.getString(0), this.args.getJSONObject(1), this.callbackContext);

--- a/src/index.js
+++ b/src/index.js
@@ -169,41 +169,6 @@ Branch.prototype.logout = function logout() {
   return execute("logout");
 };
 
-//DEPRECATED
-Branch.prototype.userCompletedAction = function userCompletedAction(
-  action,
-  metaData
-) {
-  var args = [action];
-  if (!action) {
-    return executeReject("Please set an event name");
-  }
-
-  if (metaData) {
-    args.push(metaData);
-  }
-
-  return execute("userCompletedAction", args);
-};
-
-//DEPRECATED
-Branch.prototype.sendCommerceEvent = function sendCommerceEvent(
-  action,
-  metaData
-) {
-  var args = [action];
-  if (!action) {
-    return executeReject("Please set a commerce event");
-  }
-
-  if (metaData) {
-    args.push(metaData);
-  }
-
-  return execute("sendCommerceEvent", args);
-};
-
-
 Branch.prototype.getStandardEvents = function getStandardEvents() {
   return execute("getStandardEvents");
 

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -35,7 +35,6 @@
 - (void)getFirstReferringParams:(CDVInvokedUrlCommand*)command;
 - (void)setIdentity:(CDVInvokedUrlCommand*)command;
 - (void)registerDeepLinkController:(CDVInvokedUrlCommand*)command;
-- (void)userCompletedAction:(CDVInvokedUrlCommand*)command;
 - (void)logout:(CDVInvokedUrlCommand*)command;
 - (void)delayInitToCheckForSearchAds:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -225,34 +225,6 @@ NSString * const pluginVersion = @"%BRANCH_PLUGIN_VERSION%";
   [branch registerDeepLinkController:controller forKey:[command.arguments objectAtIndex:0]];
 }
 
-- (void)userCompletedAction:(CDVInvokedUrlCommand*)command
-{
-  NSString *name;
-  NSDictionary *state;
-
-  // if a state dictionary is passed as an argument
-  if ([command.arguments count] == 2) {
-    name = [command.arguments objectAtIndex:0];
-    state = [command.arguments objectAtIndex:1];
-  }
-  else {
-    name = [command.arguments objectAtIndex:0];
-  }
-
-  Branch *branch = [self getInstance];
-
-  if (state) {
-    [branch userCompletedAction:name withState:state];
-  }
-  else {
-    [branch userCompletedAction:name];
-  }
-
-  // TODO: iOS Branch.userCompletedAction needs a callback for success or failure
-  CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: @"Success"];
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-}
-
 -(void)sendBranchEvent:(CDVInvokedUrlCommand*)command
 {
     NSString *eventName = [command.arguments objectAtIndex:0];

--- a/src/scripts/examples/templates/cordova1/index.html
+++ b/src/scripts/examples/templates/cordova1/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
-  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
+  <meta name="viewport"
+    content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
   <link rel="stylesheet" type="text/css" href="css/index.css">
   <title>Branch Testing</title>
 </head>
+
 <body>
   <fieldset>
     <legend>Branch Universal Object</legend>
@@ -15,12 +19,12 @@
   </fieldset>
   <fieldset>
     <legend>Branch Deep Link</legend>
-      <input id="alias" name="alias" type="text" placeholder="Deep link alias (optional)">
-      <section>
-        <button id="branchDeepLink">Create</button>
-        <button id="branchShareSheet">Share</button>
-      </section>
-      <input type="text" id="generated-url" placeholder="Deep link" readonly>
+    <input id="alias" name="alias" type="text" placeholder="Deep link alias (optional)">
+    <section>
+      <button id="branchDeepLink">Create</button>
+      <button id="branchShareSheet">Share</button>
+    </section>
+    <input type="text" id="generated-url" placeholder="Deep link" readonly>
   </fieldset>
   <fieldset>
     <legend>Branch Deep Link Data</legend>
@@ -49,10 +53,10 @@
     <input type="text" id="custom-action" name="custom-action" placeholder="Event Name">
     <section>
       <button id="branchEvent">Create</button>
-      <button id="branchCommerce">Commerce</button>
     </section>
   </fieldset>
   <script type="text/javascript" src="cordova.js"></script>
   <script type="text/javascript" src="js/index.js"></script>
 </body>
+
 </html>

--- a/src/scripts/examples/templates/cordova1/index.js
+++ b/src/scripts/examples/templates/cordova1/index.js
@@ -28,7 +28,6 @@ var branchSpotlight = document.getElementById("branchSpotlight");
 var branchUser = document.getElementById("branchUser");
 var branchLogout = document.getElementById("branchLogout");
 var branchEvent = document.getElementById("branchEvent");
-var branchCommerce = document.getElementById("branchCommerce");
 
 // handle DOM
 branchUniversalObject.addEventListener("click", BranchUniversalObject);
@@ -41,7 +40,6 @@ branchSpotlight.addEventListener("click", BranchSpotlight);
 branchUser.addEventListener("click", BranchUser);
 branchLogout.addEventListener("click", BranchLogout);
 branchEvent.addEventListener("click", BranchEvent);
-branchCommerce.addEventListener("click", BranchCommerce);
 
 // run
 app.initialize();
@@ -102,58 +100,6 @@ function BranchEvent() {
     custom_dictionary: 123,
     anything: "everything"
   };
-
-  Branch.userCompletedAction(event, metadata)
-    .then(function success(res) {
-      logger(res);
-    })
-    .catch(function error(err) {
-      logger(err, true);
-    });
-}
-
-function BranchCommerce() {
-  // revenue required
-  var event = {
-    revenue: 50.29,
-    currency: 148, // USD
-    transactionID: "transaction id",
-    coupon: "coupon",
-    shipping: 2.22,
-    tax: 5.11,
-    affiliation: "affiliation",
-    products: [
-      {
-        sku: "u123",
-        name: "cactus",
-        price: 4.99,
-        quantity: 2,
-        brand: "brand",
-        category: 17, // Software
-        variant: "variant"
-      },
-      {
-        sku: "u456",
-        name: "grass",
-        price: 0.0,
-        quantity: 1
-      }
-    ]
-  };
-
-  // optional
-  var metadata = {
-    custom_dictionary: 123,
-    anything: "everything"
-  };
-
-  Branch.sendCommerceEvent(event, metadata)
-    .then(function success(res) {
-      logger(res);
-    })
-    .catch(function error(err) {
-      logger(err, true);
-    });
 }
 
 function BranchFirstData() {


### PR DESCRIPTION
## Reference
SDK-2058 -- Remove v1/event code

## Summary
Removed deprecated v1/events `userCompletedAction` and `sendCommerceEvent` code from `BranchSDK.java`, `BranchSDK.h` and `BranchSDK.m`, and `index.js`, as well as from the sample apps. The changes are published in npm under the alpha package `5.2.1-alpha.0`.


## Motivation
Remove old code that has been deprecated for a sufficient amount of time.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Add the alpha package (`5.2.1-alpha.0`) to your app, or run the examples and ensure all functionality is still working.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
