### PR TITLE
[SDK-2174] Updated iOS SDK version to 3.0.0 and Android to 5.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.0.0 Dec 1, 2023
+* Update Android SDK to 5.7.5
+* Update iOS SDK to 3.0.1
+
 5.2.1 Jan 4, 2023
 * Fix Javascript method setLogging to enable logging in the native layer.
 * Update Android SDK to 5.2.7

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "6.0.0-alpha.0",
+  "version": "6.0.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "5.2.1",
+  "version": "6.0.0-alpha.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 3.0.0" />
+              <pod name="BranchSDK" spec="~> 3.0.1" />
           </pods>
       </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- Manifest configuration is done via a js script.  We should move it to this config in the future. -->
 
     <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-    <framework src="io.branch.sdk.android:library:5.7.0"/>
+    <framework src="io.branch.sdk.android:library:5.7.5"/>
   </platform>
 
   <!-- iOS -->
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 2.2.0" />
+              <pod name="BranchSDK" spec="~> 3.0.0" />
           </pods>
       </podspec>
   </platform>


### PR DESCRIPTION
## Reference
SDK-2174 -- Bump iOS SDK to 3.0.0 and Android SDK to 5.7.5

## Summary
Updated the native SDK versions.

## Motivation
Keep the plugins up to date with our native SDKs.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run a sample app on iOS and Android using the 6.0.0-alpha.0 version of the SDK.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
