### PR TITLE
[SDK-2253] Expose the setDMAParamsForEEA method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 6.1.0 Feb 28, 2024
 * Update Android SDK to 5.9.0
-* Update iOS SDK to 3.3.0
+* Update iOS SDK to 3.2.0
 * Added new method, setDMAParamsForEEA(), for setting DMA compliance parameters.
 
 6.0.0 Dec 1, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update Android SDK to 5.9.0
 * Update iOS SDK to 3.2.0
 * Added new method, setDMAParamsForEEA(), for setting DMA compliance parameters.
+* Removed the deprecated setDebug() method
 
 6.0.0 Dec 1, 2023
 * Update Android SDK to 5.7.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+6.1.0 Feb 28, 2024
+* Update Android SDK to 5.9.0
+* Update iOS SDK to 3.3.0
+* Added new method, setDMAParamsForEEA(), for setting DMA compliance parameters.
+
 6.0.0 Dec 1, 2023
 * Update Android SDK to 5.7.5
 * Update iOS SDK to 3.0.1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ SOFTWARE.
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="branch-cordova-sdk"
-  version="6.0.0">
+  version="6.1.0">
 
   <!-- Description -->
   <name>branch-cordova-sdk</name>
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- Manifest configuration is done via a js script.  We should move it to this config in the future. -->
 
     <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-    <framework src="io.branch.sdk.android:library:5.7.5"/>
+    <framework src="io.branch.sdk.android:library:5.9.0"/>
   </platform>
 
   <!-- iOS -->
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 3.0.1" />
+              <pod name="BranchSDK" spec="~> 3.3.0" />
           </pods>
       </podspec>
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -87,7 +87,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 3.3.0" />
+              <pod name="BranchSDK" spec="~> 3.2.0" />
           </pods>
       </podspec>
   </platform>

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -680,6 +680,17 @@ public class BranchSDK extends CordovaPlugin {
         //callbackContext.success();
     }
 
+    /**
+     * <p>Configures the handling of DMA parameters for users in the EEA region based on their consent.</p>
+     *
+     * @param eeaRegion                  A {@link Boolean} value indicating if the user is from the European Economic Area (EEA).
+     * @param adPersonalizationConsent   A {@link Boolean} value indicating if the user has consented to ad personalization.
+     * @param adUserDataUsageConsent     A {@link Boolean} value indicating if the user has consented to the usage of their data for ads.
+     */
+    public void setDMAParamsForEEA(boolean eeaRegion, boolean adPersonalizationConsent, boolean adUserDataUsageConsent) {
+        Branch.getInstance().setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
+    }
+
     private BranchUniversalObject getContentItem(JSONObject item) throws JSONException {
         BranchUniversalObject universalObject = new BranchUniversalObject();
         ContentMetadata contentMetadata = new ContentMetadata();
@@ -1129,6 +1140,8 @@ public class BranchSDK extends CordovaPlugin {
                             localization.put("shareWith", "Share With");
                         }
                         showShareSheet(this.args.getInt(0), this.args.getJSONObject(1), this.args.getJSONObject(2), localization);
+                    } else if (this.action.equals("setDMAParamsForEEA")) {
+                        setDMAParamsForEEA(this.args.getBoolean(0), this.args.getBoolean(1), this.args.getBoolean(2));
                     }
                 }
             } catch (JSONException e) {

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -199,6 +199,13 @@ public class BranchSDK extends CordovaPlugin {
                     }
                     cordova.getActivity().runOnUiThread(r);
                     return true;
+                } else if (action.equals("setDMAParamsForEEA")) {
+                    if (args.length() != 3) {
+                        callbackContext.error("Parameter count mismatch");
+                        return false;
+                    }
+                    cordova.getActivity().runOnUiThread(r);
+                    return true;
                 }
 
                 return true;

--- a/src/index.js
+++ b/src/index.js
@@ -300,14 +300,10 @@ Branch.prototype.getBranchQRCode = function getBranchQRCode(
 };
 
 Branch.prototype.setDMAParamsForEEA = function setDMAParamsForEEA(
-  eeaRegion,
-  adPersonalizationConsent,
-  adUserDataUsageConsent
+  eeaRegion = false,
+  adPersonalizationConsent = false,
+  adUserDataUsageConsent = false
 ) {
-  if (!eeaRegion || !adPersonalizationConsent || !adUserDataUsageConsent) {
-    return executeReject("All three parameters (eeaRegion, adPersonalizationConsent, adUserDataUsageConsent) are required.");
-  }
-
   var args = [eeaRegion, adPersonalizationConsent, adUserDataUsageConsent];
   return execute("setDMAParamsForEEA", args);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -115,13 +115,6 @@ Branch.prototype.setRequestMetadata = function setRequestMetadata(key, val) {
   return execute("setRequestMetadata", [key, val]);
 };
 
-// Deprecated. Replaced by setLogging(isEnabled) and test devices. https://help.branch.io/using-branch/docs/adding-test-devices
-Branch.prototype.setDebug = function setDebug(isEnabled) {
-  return new Promise(function promise(resolve, reject) {
-    resolve(false);
-  });
-};
-
 // For early lifecycle logging, we recommend you enable logging in the native iOS or Android code.
 Branch.prototype.setLogging = function setLogging(isEnabled) {
   var value = typeof isEnabled !== "boolean" ? false : isEnabled;

--- a/src/index.js
+++ b/src/index.js
@@ -293,12 +293,33 @@ Branch.prototype.getBranchQRCode = function getBranchQRCode(
 };
 
 Branch.prototype.setDMAParamsForEEA = function setDMAParamsForEEA(
-  eeaRegion = false,
-  adPersonalizationConsent = false,
-  adUserDataUsageConsent = false
+  eeaRegion,
+  adPersonalizationConsent,
+  adUserDataUsageConsent
 ) {
-  var args = [eeaRegion, adPersonalizationConsent, adUserDataUsageConsent];
-  return execute("setDMAParamsForEEA", args);
+  const isValid =
+    validateParam(eeaRegion, "eeaRegion") &&
+    validateParam(adPersonalizationConsent, "adPersonalizationConsent") &&
+    validateParam(adUserDataUsageConsent, "adUserDataUsageConsent");
+
+  if (isValid) {
+    var args = [eeaRegion, adPersonalizationConsent, adUserDataUsageConsent];
+    return execute("setDMAParamsForEEA", args);
+  } else {
+    return executeReject("Unable to set DMA Params");
+  }
+};
+
+const validateParam = (param, paramName) => {
+  if (param === true || param === false) {
+    return true;
+  } else {
+    console.warn(
+      `setDMAParamsForEEA: ${paramName} must be boolean, but got ${param}`
+    );
+
+    return false;
+  }
 };
 
 // export Branch object

--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,8 @@ const standardEvent = {
   STANDARD_EVENT_INVITE: "INVITE",
   STANDARD_EVENT_LOGIN: "LOGIN",
   STANDARD_EVENT_SUBSCRIBE: "SUBSCRIBE",
-  STANDARD_EVENT_START_TRIAL: "START_TRIAL"
-}
+  STANDARD_EVENT_START_TRIAL: "START_TRIAL",
+};
 
 // Branch prototype
 var Branch = function Branch() {
@@ -45,7 +45,7 @@ function execute(method, params) {
 
   if (method == "getStandardEvents") {
     return new Promise(function promise(resolve, reject) {
-      resolve(standardEvent);  
+      resolve(standardEvent);
     });
   }
 
@@ -93,7 +93,9 @@ Branch.prototype.disableTracking = function disableTracking(isEnabled) {
 
 Branch.prototype.enableTestMode = function initSession() {
   if (this.sessionInitialized) {
-    return executeReject("[enableTestMode] should be called before [initSession]");
+    return executeReject(
+      "[enableTestMode] should be called before [initSession]"
+    );
   }
   return execute("enableTestMode");
 };
@@ -137,26 +139,26 @@ Branch.prototype.setCookieBasedMatching = function setCookieBasedMatching(
 };
 
 //DEPRECATED
-Branch.prototype.delayInitToCheckForSearchAds = function delayInitToCheckForSearchAds(
-  isEnabled
-) {
-  // stub call from known issue calling it from JS
-  return new Promise(function promise(resolve, reject) {
-    resolve(false);
-  });
+Branch.prototype.delayInitToCheckForSearchAds =
+  function delayInitToCheckForSearchAds(isEnabled) {
+    // stub call from known issue calling it from JS
+    return new Promise(function promise(resolve, reject) {
+      resolve(false);
+    });
 
-  // var value = typeof isEnabled !== "boolean" ? false : isEnabled;
+    // var value = typeof isEnabled !== "boolean" ? false : isEnabled;
 
-  // return execute("delayInitToCheckForSearchAds", [value]);
-};
+    // return execute("delayInitToCheckForSearchAds", [value]);
+  };
 
 Branch.prototype.getFirstReferringParams = function getFirstReferringParams() {
   return execute("getFirstReferringParams");
 };
 
-Branch.prototype.getLatestReferringParams = function getLatestReferringParams() {
-  return execute("getLatestReferringParams");
-};
+Branch.prototype.getLatestReferringParams =
+  function getLatestReferringParams() {
+    return execute("getLatestReferringParams");
+  };
 
 Branch.prototype.setIdentity = function setIdentity(identity) {
   if (identity) {
@@ -171,13 +173,9 @@ Branch.prototype.logout = function logout() {
 
 Branch.prototype.getStandardEvents = function getStandardEvents() {
   return execute("getStandardEvents");
-
 };
 
-Branch.prototype.sendBranchEvent = function sendBranchEvent(
-  action,
-  metaData
-) {
+Branch.prototype.sendBranchEvent = function sendBranchEvent(action, metaData) {
   var args = [action];
   if (!action) {
     return executeReject("Please set a standard event");
@@ -190,86 +188,85 @@ Branch.prototype.sendBranchEvent = function sendBranchEvent(
   return execute("sendBranchEvent", args);
 };
 
-Branch.prototype.createBranchUniversalObject = function createBranchUniversalObject(
-  options
-) {
-  return new Promise(function promise(resolve, reject) {
-    execute("createBranchUniversalObject", [options]).then(
-      function success(res) {
-        var obj = {
-          message: res.message,
-          instanceId: res.branchUniversalObjectId
-        };
+Branch.prototype.createBranchUniversalObject =
+  function createBranchUniversalObject(options) {
+    return new Promise(function promise(resolve, reject) {
+      execute("createBranchUniversalObject", [options]).then(
+        function success(res) {
+          var obj = {
+            message: res.message,
+            instanceId: res.branchUniversalObjectId,
+          };
 
-        obj.registerView = function registerView() {
-          return execute("registerView", [obj.instanceId]);
-        };
+          obj.registerView = function registerView() {
+            return execute("registerView", [obj.instanceId]);
+          };
 
-        obj.generateShortUrl = function generateShortUrl(
-          analytics,
-          properties
-        ) {
-          return execute("generateShortUrl", [
-            obj.instanceId,
+          obj.generateShortUrl = function generateShortUrl(
             analytics,
             properties
-          ]);
-        };
+          ) {
+            return execute("generateShortUrl", [
+              obj.instanceId,
+              analytics,
+              properties,
+            ]);
+          };
 
-        obj.showShareSheet = function showShareSheet(
-          analytics,
-          properties,
-          shareText
-        ) {
-          var message = !shareText ? "This stuff is awesome: " : shareText;
-
-          return execute("showShareSheet", [
-            obj.instanceId,
+          obj.showShareSheet = function showShareSheet(
             analytics,
             properties,
-            message
-          ]);
-        };
+            shareText
+          ) {
+            var message = !shareText ? "This stuff is awesome: " : shareText;
 
-        obj.onShareSheetLaunched = function onShareSheetLaunched(callback) {
-          if (deviceVendor.indexOf("Apple") < 0) {
-            executeCallback("onShareLinkDialogLaunched", callback, [
-              obj.instanceId
+            return execute("showShareSheet", [
+              obj.instanceId,
+              analytics,
+              properties,
+              message,
             ]);
-          }
-        };
+          };
 
-        obj.onShareSheetDismissed = function onShareSheetDismissed(callback) {
-          executeCallback("onShareLinkDialogDismissed", callback, [
-            obj.instanceId
-          ]);
-        };
+          obj.onShareSheetLaunched = function onShareSheetLaunched(callback) {
+            if (deviceVendor.indexOf("Apple") < 0) {
+              executeCallback("onShareLinkDialogLaunched", callback, [
+                obj.instanceId,
+              ]);
+            }
+          };
 
-        obj.onLinkShareResponse = function onLinkShareResponse(callback) {
-          executeCallback("onLinkShareResponse", callback, [obj.instanceId]);
-        };
+          obj.onShareSheetDismissed = function onShareSheetDismissed(callback) {
+            executeCallback("onShareLinkDialogDismissed", callback, [
+              obj.instanceId,
+            ]);
+          };
 
-        obj.onChannelSelected = function onChannelSelected(callback) {
-          if (deviceVendor.indexOf("Apple") < 0) {
-            executeCallback("onChannelSelected", callback, [obj.instanceId]);
-          }
-        };
+          obj.onLinkShareResponse = function onLinkShareResponse(callback) {
+            executeCallback("onLinkShareResponse", callback, [obj.instanceId]);
+          };
 
-        obj.listOnSpotlight = function listOnSpotlight() {
-          if (!(deviceVendor.indexOf("Apple") < 0)) {
-            return execute("listOnSpotlight", [obj.instanceId]);
-          }
-          return executeReject("iOS Spotlight only");
-        };
+          obj.onChannelSelected = function onChannelSelected(callback) {
+            if (deviceVendor.indexOf("Apple") < 0) {
+              executeCallback("onChannelSelected", callback, [obj.instanceId]);
+            }
+          };
 
-        resolve(obj);
-      },
-      function failure(err) {
-        reject(err);
-      }
-    );
-  });
-};
+          obj.listOnSpotlight = function listOnSpotlight() {
+            if (!(deviceVendor.indexOf("Apple") < 0)) {
+              return execute("listOnSpotlight", [obj.instanceId]);
+            }
+            return executeReject("iOS Spotlight only");
+          };
+
+          resolve(obj);
+        },
+        function failure(err) {
+          reject(err);
+        }
+      );
+    });
+  };
 
 Branch.prototype.crossPlatformIds = function crossPlatformIds() {
   return execute("crossPlatformIds");
@@ -302,6 +299,18 @@ Branch.prototype.getBranchQRCode = function getBranchQRCode(
   return execute("getBranchQRCode", args);
 };
 
+Branch.prototype.setDMAParamsForEEA = function setDMAParamsForEEA(
+  eeaRegion,
+  adPersonalizationConsent,
+  adUserDataUsageConsent
+) {
+  if (!eeaRegion || !adPersonalizationConsent || !adUserDataUsageConsent) {
+    return executeReject("All three parameters (eeaRegion, adPersonalizationConsent, adUserDataUsageConsent) are required.");
+  }
+
+  var args = [eeaRegion, adPersonalizationConsent, adUserDataUsageConsent];
+  return execute("setDMAParamsForEEA", args);
+};
 
 // export Branch object
 module.exports = new Branch();

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -40,6 +40,7 @@
 - (void)setIdentity:(CDVInvokedUrlCommand*)command;
 - (void)registerDeepLinkController:(CDVInvokedUrlCommand*)command;
 - (void)logout:(CDVInvokedUrlCommand*)command;
+- (void)setDMAParamsForEEA:(CDVInvokedUrlCommand*)command;
 
 // Branch Universal Object Methods
 - (void)createBranchUniversalObject:(CDVInvokedUrlCommand*)command;

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -302,6 +302,24 @@ NSString * const pluginVersion = @"%BRANCH_PLUGIN_VERSION%";
   self.branchUniversalObjArray = [[NSMutableArray alloc] init];
 }
 
+- (void)setDMAParamsForEEA:(CDVInvokedUrlCommand*)command {
+  if (command.arguments.count < 3) {
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Insufficient arguments"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    return;
+  }
+
+  BOOL eeaRegion = [[command.arguments objectAtIndex:0] boolValue];
+  BOOL adPersonalizationConsent = [[command.arguments objectAtIndex:1] boolValue];
+  BOOL adUserDataUsageConsent = [[command.arguments objectAtIndex:2] boolValue];
+
+  [Branch setDMAParamsForEEA:eeaRegion AdPersonalizationConsent:adPersonalizationConsent AdUserDataUsageConsent:adUserDataUsageConsent];
+
+  CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+
 #pragma mark - Branch Universal Object Methods
 
 - (void)createBranchUniversalObject:(CDVInvokedUrlCommand*)command
@@ -474,20 +492,19 @@ NSString * const pluginVersion = @"%BRANCH_PLUGIN_VERSION%";
       [linkProperties addControlParam:key withValue:[arg2 objectForKey:key]];
     }
   }
+    [branchUniversalObj showShareSheetWithLinkProperties:linkProperties andShareText:shareText fromViewController:self.viewController completionWithError:^(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable error) {
+        
+        int listenerCallbackId = [[command.arguments objectAtIndex:0] intValue];
 
-  [branchUniversalObj showShareSheetWithLinkProperties:linkProperties andShareText:shareText fromViewController:self.viewController completion:^(NSString *activityType, BOOL completed) {
-
-    int listenerCallbackId = [[command.arguments objectAtIndex:0] intValue];
-
-    if (completed) {
-      NSLog(@"Share link complete");
-      [branchUniversalObj getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
-        if (!error) {
-          NSDictionary *response = [[NSDictionary alloc] initWithObjectsAndKeys:url, @"sharedLink", activityType, @"sharedChannel", nil];
-          [self doShareLinkResponse:listenerCallbackId sendResponse:response];
+        if (completed) {
+          NSLog(@"Share link complete");
+          [branchUniversalObj getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
+            if (!error) {
+              NSDictionary *response = [[NSDictionary alloc] initWithObjectsAndKeys:url, @"sharedLink", activityType, @"sharedChannel", nil];
+              [self doShareLinkResponse:listenerCallbackId sendResponse:response];
+            }
+          }];
         }
-      }];
-    }
 
     CDVPluginResult *shareDialogDismissed = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
 


### PR DESCRIPTION
## Reference
SDK-2253 -- Expose the setDMAParamsForEEA method

## Summary
Expose the setDMAParamsForEEA method in the JS layer and bump the native SDK versions.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
So clients can utilize the method in Cordova and stay compliant.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
1. In a test app, install the `branch-cordova-sdk@6.1.0-alpha.6` to get the latest version of our SDK with the new method.
2. Call the method like `Branch.setDMAParamsForEEA(true, true, true);` 
3. Observe the following request payloads for the respective DMA fields; `dma_eea, dma_ad_personalization, dma_ad_user_data` . 

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
