### PR TITLE
Add deployment target 12.0 for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,6 +71,7 @@ SOFTWARE.
       <plugins-plist key="BranchSDK" string="BranchSDK" />
 
       <config-file target="config.xml" parent="/*">
+        <preference name="deployment-target" value="12.0" />
           <feature name="BranchSDK">
               <param name="ios-package" value="BranchSDK" />
               <param name="onload" value="true" />


### PR DESCRIPTION
## Summary
Add deployment target 12.0 for iOS to fix build error

## Motivation
To fix build error "Specs satisfying the `BranchSDK (~> 3.2.0)` dependency were found, but they required a higher minimum deployment target."

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Install the plugin on iOS and create an app build.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
