### PR TITLE
[SDK-2446] Updated Native SDK versions and added iOS deployment target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+6.2.0 May 28, 2024
+* Update Android SDK to 5.12.0
+* Update iOS SDK to 3.4.3
+* Updated iOS deployment target to 12.0
 
 6.1.0 Feb 28, 2024
 * Update Android SDK to 5.9.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ SOFTWARE.
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="branch-cordova-sdk"
-  version="6.1.0">
+  version="6.2.0">
 
   <!-- Description -->
   <name>branch-cordova-sdk</name>
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- Manifest configuration is done via a js script.  We should move it to this config in the future. -->
 
     <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-    <framework src="io.branch.sdk.android:library:5.9.0"/>
+    <framework src="io.branch.sdk.android:library:5.12.0"/>
   </platform>
 
   <!-- iOS -->
@@ -71,6 +71,7 @@ SOFTWARE.
       <plugins-plist key="BranchSDK" string="BranchSDK" />
 
       <config-file target="config.xml" parent="/*">
+          <preference name="deployment-target" value="12.0" />
           <feature name="BranchSDK">
               <param name="ios-package" value="BranchSDK" />
               <param name="onload" value="true" />
@@ -87,7 +88,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 3.2.0" />
+              <pod name="BranchSDK" spec="~> 3.4.3" />
           </pods>
       </podspec>
   </platform>


### PR DESCRIPTION
## Reference
SDK-2446 -- Updated plugin.xml to Specify Minimum iOS Deployment Target

## Summary
Updated the Branch iOS SDK to 3.4.3 and the Android SDK to 5.12.0. Also added a deployment target for iOS 12 to fix a build error faced by some clients.

## Motivation
Provide updated native SDK features to clients and fix a build issue.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Integrate the Cordova plugin into a test app via the npm alpha package: `6.2.0-alpha.0`. Ensure that the Android and iOS version especially build properly.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
