### PR TITLE
fix(ios): Remove deployment-target

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,6 @@ SOFTWARE.
       <plugins-plist key="BranchSDK" string="BranchSDK" />
 
       <config-file target="config.xml" parent="/*">
-          <preference name="deployment-target" value="12.0" />
           <feature name="BranchSDK">
               <param name="ios-package" value="BranchSDK" />
               <param name="onload" value="true" />


### PR DESCRIPTION
## Summary
Removes the `deployment-target` preference that `plugin.xml` injects into consuming apps' `config.xml`, and documents that apps should set their own iOS deployment target instead.

## Motivation
Per the [Cordova config.xml reference](https://cordova.apache.org/docs/en/latest/config_ref/index.html), `deployment-target` is meant to be set by the app in its own `config.xml`. This plugin currently also injects `<preference name="deployment-target" value="12.0" />` via `config-file`, which conflicts with (and can silently override) the value an app has explicitly set for itself.

In practice this causes real build issues for consumers — e.g. conflicts with `cordova-plugin-firebasex` pods when both plugins try to control the same setting (see comments below). Since a plugin shouldn't be dictating an app-level build setting that the app owner may need to control for their own dependency graph, the fix is to stop injecting it here and let apps own it via their own `config.xml`, as documented at https://help.branch.io/developers-hub/docs/cordova-phonegap-ionic#configure-app.

This has been requested by multiple consumers of the SDK:
- @fluffysaur: "would like this merged as it's causing issues with cordova-plugin-firebasex pods" ([comment](https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/pull/736#issuecomment-2882664675))
- @dmitry-platogo: "We are also experiencing the issues with the `deployment-target` explicitly set, would really like this to be merged" ([comment](https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking-attribution/pull/736#issuecomment-5035523736))

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] This change requires a documentation update

**Note on compatibility:** apps that don't already set their own `deployment-target` in `config.xml` will fall back to the default provided by `cordova-ios` itself instead of this plugin's `12.0`. Apps that need a specific minimum should set it explicitly in their own `config.xml`, per https://help.branch.io/developers-hub/docs/cordova-phonegap-ionic#configure-app.

## Testing Instructions
1. Add a `<preference name="deployment-target" value="15.0" />` to a test app's `config.xml`.
2. Run `cordova prepare ios` with this plugin installed.
3. Before this change: the plugin's `config-file` entry (`12.0`) conflicts with/overrides the app's own preference.
4. After this change: only the app's `config.xml` value is applied, and the generated Xcode project uses `15.0`.

cc @BranchMetrics/saas-sdk-devs for visibility.
