### PR TITLE
[SDK-2526] Added CPP level support to Cordova and release 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+6.5.0 Jan 14, 2025
+* Update Android SDK to 5.15.0
+* Update iOS SDK to 3.8.0
+* Added new method `setConsumerProtectionAttributionLevel` to set CPP level 
+
 6.4.0 Nov 1, 2024
 * Update Android SDK to 5.13.0
 * Update iOS SDK to 3.6.5

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "branch-cordova-sdk",
   "description": "Branch Metrics Cordova SDK",
   "main": "src/index.js",
-  "version": "6.5.0-alpha.0",
+  "version": "6.5.0",
   "homepage": "https://github.com/BranchMetrics/cordova-ionic-phonegap-branch-deep-linking",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@ SOFTWARE.
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="branch-cordova-sdk"
-  version="6.4.0">
+  version="6.5.0">
 
   <!-- Description -->
   <name>branch-cordova-sdk</name>
@@ -63,7 +63,7 @@ SOFTWARE.
     <!-- Manifest configuration is done via a js script.  We should move it to this config in the future. -->
 
     <source-file src="src/android/io/branch/BranchSDK.java" target-dir="src/io/branch" />
-    <framework src="io.branch.sdk.android:library:5.13.0"/>
+    <framework src="io.branch.sdk.android:library:5.15.0"/>
   </platform>
 
   <!-- iOS -->
@@ -88,7 +88,7 @@ SOFTWARE.
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods>
-              <pod name="BranchSDK" spec="~> 3.6.5" />
+              <pod name="BranchSDK" spec="~> 3.8.0" />
           </pods>
       </podspec>
   </platform>

--- a/src/android/io/branch/BranchSDK.java
+++ b/src/android/io/branch/BranchSDK.java
@@ -30,6 +30,7 @@ import io.branch.referral.util.BranchEvent;
 import io.branch.referral.util.ContentMetadata;
 import io.branch.referral.util.CurrencyType;
 import io.branch.referral.util.ShareSheetStyle;
+import io.branch.referral.BranchAttributionLevel;
 
 
 public class BranchSDK extends CordovaPlugin {
@@ -112,7 +113,14 @@ public class BranchSDK extends CordovaPlugin {
             return true;
         } else {
             if (this.instance != null) {
-                if (action.equals("setIdentity")) {
+                if (action.equals("setConsumerProtectionAttributionLevel")) {
+                    if (args.length() != 1) {
+                        callbackContext.error("Parameter count mismatch");
+                        return false;
+                    }
+                    cordova.getActivity().runOnUiThread(r);
+                    return true;
+                } else if (action.equals("setIdentity")) {
                     cordova.getActivity().runOnUiThread(r);
                     return true;
                 } else if (action.equals("sendBranchEvent")) {
@@ -698,6 +706,44 @@ public class BranchSDK extends CordovaPlugin {
         Branch.getInstance().setDMAParamsForEEA(eeaRegion, adPersonalizationConsent, adUserDataUsageConsent);
     }
 
+    /**
+     * <p>Sets the CPP level.</p>
+     * 
+     * @param level A {@link String} value indicating the desired attribution level. Valid values are:
+     *             "FULL" - Full attribution with all data collection enabled
+     *             "REDUCED" - Reduced attribution with limited data collection
+     *             "MINIMAL" - Minimal attribution with very limited data collection
+     *             "NONE" - No attribution or data collection
+     * @param callbackContext A callback to execute at the end of this method
+     */
+
+    private void setConsumerProtectionAttributionLevel(String level, CallbackContext callbackContext) {
+        Branch branch = Branch.getInstance();
+        BranchAttributionLevel attributionLevel;
+        
+        switch (level) {
+            case "FULL":
+                attributionLevel = BranchAttributionLevel.FULL;
+                break;
+            case "REDUCED":
+                attributionLevel = BranchAttributionLevel.REDUCED;
+                break;
+            case "MINIMAL":
+                attributionLevel = BranchAttributionLevel.MINIMAL;
+                break;
+            case "NONE":
+                attributionLevel = BranchAttributionLevel.NONE;
+                break;
+            default:
+                Log.w(LCAT, "Invalid attribution level: " + level);
+                callbackContext.error("Invalid attribution level: " + level);
+                return;
+        }
+        
+        branch.setConsumerProtectionAttributionLevel(attributionLevel);
+        callbackContext.success("Success");
+    }
+
     private BranchUniversalObject getContentItem(JSONObject item) throws JSONException {
         BranchUniversalObject universalObject = new BranchUniversalObject();
         ContentMetadata contentMetadata = new ContentMetadata();
@@ -1149,6 +1195,8 @@ public class BranchSDK extends CordovaPlugin {
                         showShareSheet(this.args.getInt(0), this.args.getJSONObject(1), this.args.getJSONObject(2), localization);
                     } else if (this.action.equals("setDMAParamsForEEA")) {
                         setDMAParamsForEEA(this.args.getBoolean(0), this.args.getBoolean(1), this.args.getBoolean(2));
+                    } else if (this.action.equals("setConsumerProtectionAttributionLevel")) {
+                        setConsumerProtectionAttributionLevel(this.args.getString(0), this.callbackContext);
                     }
                 }
             } catch (JSONException e) {
@@ -1156,4 +1204,6 @@ public class BranchSDK extends CordovaPlugin {
             }
         }
     }
+
+
 }

--- a/src/index.js
+++ b/src/index.js
@@ -322,5 +322,13 @@ const validateParam = (param, paramName) => {
   }
 };
 
+Branch.prototype.setConsumerProtectionAttributionLevel =
+  function setConsumerProtectionAttributionLevel(level) {
+    if (typeof level !== "string") {
+      return executeReject("Attribution level must be a string");
+    }
+    return execute("setConsumerProtectionAttributionLevel", [level]);
+  };
+
 // export Branch object
 module.exports = new Branch();

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -41,6 +41,7 @@
 - (void)registerDeepLinkController:(CDVInvokedUrlCommand*)command;
 - (void)logout:(CDVInvokedUrlCommand*)command;
 - (void)setDMAParamsForEEA:(CDVInvokedUrlCommand*)command;
+- (void)setConsumerProtectionAttributionLevel:(CDVInvokedUrlCommand*)command;
 
 // Branch Universal Object Methods
 - (void)createBranchUniversalObject:(CDVInvokedUrlCommand*)command;
@@ -53,5 +54,6 @@
 
 // Branch Query Methods
 - (void)lastAttributedTouchData:(CDVInvokedUrlCommand *)command;
+
 
 @end

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -319,6 +319,30 @@ NSString * const pluginVersion = @"%BRANCH_PLUGIN_VERSION%";
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)setConsumerProtectionAttributionLevel:(CDVInvokedUrlCommand*)command {
+    NSString *level = [command.arguments objectAtIndex:0];
+    BranchAttributionLevel attributionLevel;
+    
+    if ([level isEqualToString:@"FULL"]) {
+        attributionLevel = BranchAttributionLevelFull;
+    } else if ([level isEqualToString:@"REDUCED"]) {
+        attributionLevel = BranchAttributionLevelReduced;
+    } else if ([level isEqualToString:@"MINIMAL"]) {
+        attributionLevel = BranchAttributionLevelMinimal;
+    } else if ([level isEqualToString:@"NONE"]) {
+        attributionLevel = BranchAttributionLevelNone;
+    } else {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR 
+                                                        messageAsString:@"Invalid attribution level"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
+    
+    [[Branch getInstance] setConsumerProtectionAttributionLevel:attributionLevel];
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
 
 #pragma mark - Branch Universal Object Methods
 
@@ -745,5 +769,7 @@ NSString * const pluginVersion = @"%BRANCH_PLUGIN_VERSION%";
 
   [self.viewController presentViewController:shareViewController animated:YES completion:nil];
 }
+
+
 
 @end


### PR DESCRIPTION
## Reference
SDK-2526 -- Expose the CPP method in the JS layer

## Summary
Added support for setting the CPP level in the Cordova JS Layer. Also updated the native iOS and Android SDKs.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To give clients access to the latest SDK features.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Install the `6.5.0-alpha.0` package and test the new method, `setConsumerProtectionAttributionLevel`.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.