### PR TITLE
Sdk change major

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,10 +154,6 @@ Branch.prototype.getLatestReferringParams =
     return execute("getLatestReferringParams");
   };
 
-Branch.prototype.getLastNativeInitDebug = function getLastNativeInitDebug() {
-  return execute("getLastNativeInitDebug");
-};
-
 Branch.prototype.setIdentity = function setIdentity(identity) {
   if (identity) {
     return execute("setIdentity", [String(identity)]);

--- a/src/index.js
+++ b/src/index.js
@@ -154,6 +154,10 @@ Branch.prototype.getLatestReferringParams =
     return execute("getLatestReferringParams");
   };
 
+Branch.prototype.getLastNativeInitDebug = function getLastNativeInitDebug() {
+  return execute("getLastNativeInitDebug");
+};
+
 Branch.prototype.setIdentity = function setIdentity(identity) {
   if (identity) {
     return execute("setIdentity", [String(identity)]);

--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -20,8 +20,14 @@
 
 @implementation AppDelegate (BranchSDK)
 
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  [BranchSDK noteDidFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
 // Respond to URI scheme links
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  [BranchSDK noteOpenURL:url options:options];
   [BranchSDK setPendingOpenURL:url options:options];
   // pass the url to the handle deep link call
   if (![[Branch getInstance] application:app openURL:url options:options]) {
@@ -35,6 +41,7 @@
 
 // Respond to Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {
+  [BranchSDK noteUserActivity:userActivity];
   [BranchSDK setPendingUserActivity:userActivity];
   if (![[Branch getInstance] continueUserActivity:userActivity]) {
     // send unhandled URL to notification

--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -21,6 +21,7 @@
 
 // Respond to URI scheme links
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  [BranchSDK setPendingOpenURL:url options:options];
   // pass the url to the handle deep link call
   if (![[Branch getInstance] application:app openURL:url options:options]) {
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
@@ -33,6 +34,7 @@
 
 // Respond to Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {
+  [BranchSDK setPendingUserActivity:userActivity];
   if (![[Branch getInstance] continueUserActivity:userActivity]) {
     // send unhandled URL to notification
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {

--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -16,6 +16,9 @@
 @interface AppDelegate (BranchSDK)
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler;
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions;
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity;
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts;
 
 @end
 
@@ -60,6 +63,8 @@ static void BSDKSwizzleSelectorOnClass(Class targetClass, SEL originalSelector, 
   dispatch_once(&onceToken, ^{
     Class appDelegateClass = NSClassFromString(@"AppDelegate");
     Class cordovaAppDelegateClass = NSClassFromString(@"CDVAppDelegate");
+    Class sceneDelegateClass = NSClassFromString(@"SceneDelegate");
+    Class cordovaSceneDelegateClass = NSClassFromString(@"CDVSceneDelegate");
 
     BSDKSwizzleSelectorOnClass(appDelegateClass,
                                @selector(application:didFinishLaunchingWithOptions:),
@@ -88,6 +93,27 @@ static void BSDKSwizzleSelectorOnClass(Class targetClass, SEL originalSelector, 
     BSDKSwizzleSelectorOnClass(cordovaAppDelegateClass,
                                @selector(application:didReceiveRemoteNotification:),
                                @selector(bsdk_application:didReceiveRemoteNotification:));
+
+    BSDKSwizzleSelectorOnClass(sceneDelegateClass,
+                               @selector(scene:willConnectToSession:options:),
+                               @selector(bsdk_scene:willConnectToSession:options:));
+    BSDKSwizzleSelectorOnClass(cordovaSceneDelegateClass,
+                               @selector(scene:willConnectToSession:options:),
+                               @selector(bsdk_scene:willConnectToSession:options:));
+
+    BSDKSwizzleSelectorOnClass(sceneDelegateClass,
+                               @selector(scene:continueUserActivity:),
+                               @selector(bsdk_scene:continueUserActivity:));
+    BSDKSwizzleSelectorOnClass(cordovaSceneDelegateClass,
+                               @selector(scene:continueUserActivity:),
+                               @selector(bsdk_scene:continueUserActivity:));
+
+    BSDKSwizzleSelectorOnClass(sceneDelegateClass,
+                               @selector(scene:openURLContexts:),
+                               @selector(bsdk_scene:openURLContexts:));
+    BSDKSwizzleSelectorOnClass(cordovaSceneDelegateClass,
+                               @selector(scene:openURLContexts:),
+                               @selector(bsdk_scene:openURLContexts:));
   });
 }
 
@@ -156,6 +182,48 @@ static void BSDKSwizzleSelectorOnClass(Class targetClass, SEL originalSelector, 
                                     @selector(application:didReceiveRemoteNotification:),
                                     @selector(bsdk_application:didReceiveRemoteNotification:))) {
     [self bsdk_application:application didReceiveRemoteNotification:userInfo];
+  }
+}
+
+- (void)bsdk_scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+  [BranchSDK noteSceneWillConnectWithURLContexts:connectionOptions.URLContexts
+                                  userActivities:connectionOptions.userActivities];
+
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(scene:willConnectToSession:options:),
+                                    @selector(bsdk_scene:willConnectToSession:options:))) {
+    [self bsdk_scene:scene willConnectToSession:session options:connectionOptions];
+  }
+}
+
+- (void)bsdk_scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity {
+  [BranchSDK noteSceneUserActivity:userActivity];
+  [[Branch getInstance] continueUserActivity:userActivity];
+
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(scene:continueUserActivity:),
+                                    @selector(bsdk_scene:continueUserActivity:))) {
+    [self bsdk_scene:scene continueUserActivity:userActivity];
+  }
+}
+
+- (void)bsdk_scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+  [BranchSDK noteSceneOpenURLContexts:URLContexts];
+
+  UIOpenURLContext *context = [URLContexts allObjects].firstObject;
+  if (context != nil) {
+    [[Branch getInstance] application:[UIApplication sharedApplication]
+                              openURL:context.URL
+                              options:@{
+                                UIApplicationOpenURLOptionsSourceApplicationKey: context.options.sourceApplication ?: @"",
+                                UIApplicationOpenURLOptionsAnnotationKey: context.options.annotation ?: @""
+                              }];
+  }
+
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(scene:openURLContexts:),
+                                    @selector(bsdk_scene:openURLContexts:))) {
+    [self bsdk_scene:scene openURLContexts:URLContexts];
   }
 }
 

--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -11,6 +11,7 @@
 
 // Provides Ionic Capacitor compatibility
 #import <Cordova/CDVPlugin.h>
+#import <objc/runtime.h>
 
 @interface AppDelegate (BranchSDK)
 
@@ -18,48 +19,143 @@
 
 @end
 
+static BOOL BSDKHasOriginalImplementation(id self, SEL originalSelector, SEL swizzledSelector) {
+  IMP originalIMP = class_getMethodImplementation([self class], originalSelector);
+  IMP swizzledIMP = class_getMethodImplementation([self class], swizzledSelector);
+  return originalIMP != swizzledIMP;
+}
+
+static void BSDKSwizzleSelectorOnClass(Class targetClass, SEL originalSelector, SEL swizzledSelector) {
+  if (targetClass == Nil) {
+    return;
+  }
+
+  Method sourceMethod = class_getInstanceMethod([AppDelegate class], swizzledSelector);
+  if (sourceMethod == NULL) {
+    return;
+  }
+
+  class_addMethod(targetClass,
+                  swizzledSelector,
+                  method_getImplementation(sourceMethod),
+                  method_getTypeEncoding(sourceMethod));
+
+  Method originalMethod = class_getInstanceMethod(targetClass, originalSelector);
+  Method targetSwizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector);
+
+  if (originalMethod != NULL && targetSwizzledMethod != NULL) {
+    method_exchangeImplementations(originalMethod, targetSwizzledMethod);
+  } else if (targetSwizzledMethod != NULL) {
+    class_addMethod(targetClass,
+                    originalSelector,
+                    method_getImplementation(targetSwizzledMethod),
+                    method_getTypeEncoding(targetSwizzledMethod));
+  }
+}
+
 @implementation AppDelegate (BranchSDK)
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
++ (void)load {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    Class appDelegateClass = NSClassFromString(@"AppDelegate");
+    Class cordovaAppDelegateClass = NSClassFromString(@"CDVAppDelegate");
+
+    BSDKSwizzleSelectorOnClass(appDelegateClass,
+                               @selector(application:didFinishLaunchingWithOptions:),
+                               @selector(bsdk_application:didFinishLaunchingWithOptions:));
+    BSDKSwizzleSelectorOnClass(cordovaAppDelegateClass,
+                               @selector(application:didFinishLaunchingWithOptions:),
+                               @selector(bsdk_application:didFinishLaunchingWithOptions:));
+
+    BSDKSwizzleSelectorOnClass(appDelegateClass,
+                               @selector(application:openURL:options:),
+                               @selector(bsdk_application:openURL:options:));
+    BSDKSwizzleSelectorOnClass(cordovaAppDelegateClass,
+                               @selector(application:openURL:options:),
+                               @selector(bsdk_application:openURL:options:));
+
+    BSDKSwizzleSelectorOnClass(appDelegateClass,
+                               @selector(application:continueUserActivity:restorationHandler:),
+                               @selector(bsdk_application:continueUserActivity:restorationHandler:));
+    BSDKSwizzleSelectorOnClass(cordovaAppDelegateClass,
+                               @selector(application:continueUserActivity:restorationHandler:),
+                               @selector(bsdk_application:continueUserActivity:restorationHandler:));
+
+    BSDKSwizzleSelectorOnClass(appDelegateClass,
+                               @selector(application:didReceiveRemoteNotification:),
+                               @selector(bsdk_application:didReceiveRemoteNotification:));
+    BSDKSwizzleSelectorOnClass(cordovaAppDelegateClass,
+                               @selector(application:didReceiveRemoteNotification:),
+                               @selector(bsdk_application:didReceiveRemoteNotification:));
+  });
+}
+
+- (BOOL)bsdk_application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [BranchSDK noteDidFinishLaunchingWithOptions:launchOptions];
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(application:didFinishLaunchingWithOptions:),
+                                    @selector(bsdk_application:didFinishLaunchingWithOptions:))) {
+    return [self bsdk_application:application didFinishLaunchingWithOptions:launchOptions];
+  }
   return YES;
 }
 
 // Respond to URI scheme links
-- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+- (BOOL)bsdk_application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
   [BranchSDK noteOpenURL:url options:options];
   [BranchSDK setPendingOpenURL:url options:options];
+  BOOL branchHandled = [[Branch getInstance] application:app openURL:url options:options];
+  BOOL originalResult = YES;
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(application:openURL:options:),
+                                    @selector(bsdk_application:openURL:options:))) {
+    originalResult = [self bsdk_application:app openURL:url options:options];
+  }
   // pass the url to the handle deep link call
-  if (![[Branch getInstance] application:app openURL:url options:options]) {
+  if (!branchHandled) {
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
     // send unhandled URL to notification
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"BSDKPostUnhandledURL" object:[url absoluteString]]];
   }
-  return YES;
+  return originalResult;
 }
 
 // Respond to Universal Links
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {
+- (BOOL)bsdk_application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {
   [BranchSDK noteUserActivity:userActivity];
   [BranchSDK setPendingUserActivity:userActivity];
-  if (![[Branch getInstance] continueUserActivity:userActivity]) {
+  BOOL branchHandled = [[Branch getInstance] continueUserActivity:userActivity];
+  BOOL originalResult = YES;
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(application:continueUserActivity:restorationHandler:),
+                                    @selector(bsdk_application:continueUserActivity:restorationHandler:))) {
+    originalResult = [self bsdk_application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  }
+  if (!branchHandled) {
     // send unhandled URL to notification
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
       [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"BSDKPostUnhandledURL" object:[userActivity.webpageURL absoluteString]]];
     }
   }
 
-  return YES;
+  return originalResult;
 }
 
 // Respond to Push Notifications
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
+- (void)bsdk_application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
   @try {
     [[Branch getInstance] handlePushNotification:userInfo];
   }
   @catch (NSException *exception) {
     [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"BSDKPostUnhandledURL" object:userInfo]];
+  }
+
+  if (BSDKHasOriginalImplementation(self,
+                                    @selector(application:didReceiveRemoteNotification:),
+                                    @selector(bsdk_application:didReceiveRemoteNotification:))) {
+    [self bsdk_application:application didReceiveRemoteNotification:userInfo];
   }
 }
 

--- a/src/ios/AppDelegate+BranchSdk.m
+++ b/src/ios/AppDelegate+BranchSdk.m
@@ -1,6 +1,7 @@
 #import "AppDelegate.h"
 
 #import "BranchNPM.h"
+#import "BranchSDK.h"
 
 #ifdef BRANCH_NPM
 #import "Branch.h"

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -45,6 +45,7 @@
 - (void)setSDKWaitTimeForThirdPartyAPIs:(CDVInvokedUrlCommand*)command;
 - (void)setAnonID:(CDVInvokedUrlCommand*)command;
 - (void)setODMInfo:(CDVInvokedUrlCommand*)command;
+- (void)getLastNativeInitDebug:(CDVInvokedUrlCommand*)command;
 
 // Branch Universal Object Methods
 - (void)createBranchUniversalObject:(CDVInvokedUrlCommand*)command;

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -45,7 +45,6 @@
 - (void)setSDKWaitTimeForThirdPartyAPIs:(CDVInvokedUrlCommand*)command;
 - (void)setAnonID:(CDVInvokedUrlCommand*)command;
 - (void)setODMInfo:(CDVInvokedUrlCommand*)command;
-- (void)getLastNativeInitDebug:(CDVInvokedUrlCommand*)command;
 
 // Branch Universal Object Methods
 - (void)createBranchUniversalObject:(CDVInvokedUrlCommand*)command;
@@ -68,10 +67,10 @@
                              userActivities:(NSSet<NSUserActivity *> *)userActivities;
 + (void)noteSceneOpenURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts;
 + (void)noteSceneUserActivity:(NSUserActivity *)userActivity;
-+ (NSDictionary *)pendingLaunchOptions;
 + (NSURL *)pendingOpenURL;
 + (NSDictionary *)pendingOpenURLOptions;
 + (NSUserActivity *)pendingUserActivity;
++ (NSDictionary *)pendingLaunchOptions;
 + (void)clearPendingLaunchContext;
 
 @end

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -58,5 +58,11 @@
 // Branch Query Methods
 - (void)lastAttributedTouchData:(CDVInvokedUrlCommand *)command;
 
++ (void)setPendingOpenURL:(NSURL *)url options:(NSDictionary *)options;
++ (void)setPendingUserActivity:(NSUserActivity *)userActivity;
++ (NSURL *)pendingOpenURL;
++ (NSDictionary *)pendingOpenURLOptions;
++ (NSUserActivity *)pendingUserActivity;
++ (void)clearPendingLaunchContext;
 
 @end

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -64,6 +64,7 @@
 + (void)noteOpenURL:(NSURL *)url options:(NSDictionary *)options;
 + (void)noteUserActivity:(NSUserActivity *)userActivity;
 + (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
++ (NSDictionary *)pendingLaunchOptions;
 + (NSURL *)pendingOpenURL;
 + (NSDictionary *)pendingOpenURLOptions;
 + (NSUserActivity *)pendingUserActivity;

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -64,6 +64,10 @@
 + (void)noteOpenURL:(NSURL *)url options:(NSDictionary *)options;
 + (void)noteUserActivity:(NSUserActivity *)userActivity;
 + (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
++ (void)noteSceneWillConnectWithURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+                             userActivities:(NSSet<NSUserActivity *> *)userActivities;
++ (void)noteSceneOpenURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts;
++ (void)noteSceneUserActivity:(NSUserActivity *)userActivity;
 + (NSDictionary *)pendingLaunchOptions;
 + (NSURL *)pendingOpenURL;
 + (NSDictionary *)pendingOpenURLOptions;

--- a/src/ios/BranchSDK.h
+++ b/src/ios/BranchSDK.h
@@ -61,6 +61,9 @@
 
 + (void)setPendingOpenURL:(NSURL *)url options:(NSDictionary *)options;
 + (void)setPendingUserActivity:(NSUserActivity *)userActivity;
++ (void)noteOpenURL:(NSURL *)url options:(NSDictionary *)options;
++ (void)noteUserActivity:(NSUserActivity *)userActivity;
++ (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 + (NSURL *)pendingOpenURL;
 + (NSDictionary *)pendingOpenURLOptions;
 + (NSUserActivity *)pendingUserActivity;

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -61,6 +61,68 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   }
 }
 
++ (void)noteSceneWillConnectWithURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+                             userActivities:(NSSet<NSUserActivity *> *)userActivities
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawSceneWillConnect"];
+  [debug setObject:@([URLContexts count]) forKey:@"sceneURLContextCount"];
+  [debug setObject:@([userActivities count]) forKey:@"sceneUserActivityCount"];
+
+  UIOpenURLContext *context = [URLContexts allObjects].firstObject;
+  if (context != nil) {
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    if (context.options.sourceApplication != nil) {
+      [options setObject:context.options.sourceApplication
+                  forKey:UIApplicationOpenURLOptionsSourceApplicationKey];
+    }
+    if (context.options.annotation != nil) {
+      [options setObject:context.options.annotation
+                  forKey:UIApplicationOpenURLOptionsAnnotationKey];
+    }
+    [options setObject:@"sceneWillConnect" forKey:@"source"];
+    [BranchSDK noteOpenURL:context.URL options:options];
+    [BranchSDK setPendingOpenURL:context.URL options:options];
+  }
+
+  NSUserActivity *userActivity = [userActivities allObjects].firstObject;
+  if (userActivity != nil) {
+    [BranchSDK noteUserActivity:userActivity];
+    [BranchSDK setPendingUserActivity:userActivity];
+  }
+}
+
++ (void)noteSceneOpenURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawSceneOpenURLContexts"];
+  [debug setObject:@([URLContexts count]) forKey:@"sceneOpenURLContextCount"];
+
+  UIOpenURLContext *context = [URLContexts allObjects].firstObject;
+  if (context != nil) {
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    if (context.options.sourceApplication != nil) {
+      [options setObject:context.options.sourceApplication
+                  forKey:UIApplicationOpenURLOptionsSourceApplicationKey];
+    }
+    if (context.options.annotation != nil) {
+      [options setObject:context.options.annotation
+                  forKey:UIApplicationOpenURLOptionsAnnotationKey];
+    }
+    [options setObject:@"sceneOpenURLContexts" forKey:@"source"];
+    [BranchSDK noteOpenURL:context.URL options:options];
+    [BranchSDK setPendingOpenURL:context.URL options:options];
+  }
+}
+
++ (void)noteSceneUserActivity:(NSUserActivity *)userActivity
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawSceneContinueUserActivity"];
+  [BranchSDK noteUserActivity:userActivity];
+  [BranchSDK setPendingUserActivity:userActivity];
+}
+
 + (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSMutableDictionary *debug = [BranchSDK lifecycleDebug];

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -122,12 +122,40 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
 {
   self.branchUniversalObjArray = [[NSMutableArray alloc] init];
   [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURLNotification:) name:CDVPluginHandleOpenURLNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOpenURLWithAppSourceAndAnnotationNotification:) name:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:nil];
 }
 
 - (void)handleOpenURLNotification:(NSNotification*)notification
 {
     NSURL* url = [notification object];
+    [BranchSDK noteOpenURL:url options:@{ @"source": @"CDVPluginHandleOpenURLNotification" }];
+    [BranchSDK setPendingOpenURL:url options:@{}];
     [[Branch getInstance] application:[UIApplication sharedApplication]  openURL:url options:@{}];
+}
+
+- (void)handleOpenURLWithAppSourceAndAnnotationNotification:(NSNotification*)notification
+{
+    NSDictionary *openURLData = [notification object];
+    NSURL *url = [openURLData objectForKey:@"url"];
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+
+    id sourceApplication = [openURLData objectForKey:@"sourceApplication"];
+    if (sourceApplication != nil) {
+      [options setObject:sourceApplication forKey:UIApplicationOpenURLOptionsSourceApplicationKey];
+    }
+
+    id annotation = [openURLData objectForKey:@"annotation"];
+    if (annotation != nil) {
+      [options setObject:annotation forKey:UIApplicationOpenURLOptionsAnnotationKey];
+    }
+
+    [options setObject:@"CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification" forKey:@"source"];
+
+    if (url != nil) {
+      [BranchSDK noteOpenURL:url options:options];
+      [BranchSDK setPendingOpenURL:url options:options];
+      [[Branch getInstance] application:[UIApplication sharedApplication] openURL:url options:options];
+    }
 }
 
 #pragma mark - Private APIs

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -4,6 +4,7 @@ NSString * const pluginVersion = @"6.6.1";
 static NSURL *branchPendingOpenURL = nil;
 static NSDictionary *branchPendingOpenURLOptions = nil;
 static NSUserActivity *branchPendingUserActivity = nil;
+static NSDictionary *branchLastNativeInitDebug = nil;
 
 @interface BranchSDK()
 
@@ -46,6 +47,16 @@ static NSUserActivity *branchPendingUserActivity = nil;
   branchPendingOpenURL = nil;
   branchPendingOpenURLOptions = nil;
   branchPendingUserActivity = nil;
+}
+
++ (void)setLastNativeInitDebug:(NSDictionary *)debugInfo
+{
+  branchLastNativeInitDebug = debugInfo;
+}
+
++ (NSDictionary *)lastNativeInitDebug
+{
+  return branchLastNativeInitDebug;
 }
 
 - (void)pluginInitialize
@@ -142,8 +153,34 @@ static NSUserActivity *branchPendingUserActivity = nil;
     [[Branch getInstance] application:[UIApplication sharedApplication] openURL:pendingOpenURL options:openOptions];
   }
 
+  NSMutableDictionary *preInitDebug = [NSMutableDictionary dictionary];
+  [preInitDebug setObject:pluginVersion forKey:@"pluginVersion"];
+  [preInitDebug setObject:[NSNumber numberWithBool:(pendingUserActivity != nil)] forKey:@"hadPendingUserActivity"];
+  [preInitDebug setObject:[NSNumber numberWithBool:(pendingOpenURL != nil)] forKey:@"hadPendingOpenURL"];
+  if (pendingOpenURL != nil) {
+    [preInitDebug setObject:[pendingOpenURL absoluteString] forKey:@"pendingOpenURL"];
+  }
+  if (pendingUserActivity != nil) {
+    [preInitDebug setObject:pendingUserActivity.activityType ?: @"" forKey:@"pendingUserActivityType"];
+    if ([pendingUserActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && pendingUserActivity.webpageURL != nil) {
+      [preInitDebug setObject:[pendingUserActivity.webpageURL absoluteString] forKey:@"pendingWebpageURL"];
+    }
+  }
+  [BranchSDK setLastNativeInitDebug:preInitDebug];
+
   [[Branch getInstance] initSessionWithLaunchOptions:nil andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
     [BranchSDK clearPendingLaunchContext];
+
+    NSMutableDictionary *nativeDebug = [NSMutableDictionary dictionaryWithDictionary:[BranchSDK lastNativeInitDebug] ?: @{}];
+    [nativeDebug setObject:[NSNumber numberWithBool:(params != nil)] forKey:@"nativeCallbackHasParams"];
+    [nativeDebug setObject:[NSNumber numberWithUnsignedInteger:(params ? [params count] : 0)] forKey:@"nativeParamsCount"];
+    if (params != nil) {
+      [nativeDebug setObject:params forKey:@"nativeParams"];
+    }
+    if (error != nil) {
+      [nativeDebug setObject:[error localizedDescription] ?: @"Unknown Branch init error" forKey:@"nativeError"];
+    }
+    [BranchSDK setLastNativeInitDebug:nativeDebug];
 
     NSString *resultString = nil;
     CDVPluginResult *pluginResult = nil;
@@ -182,6 +219,20 @@ static NSUserActivity *branchPendingUserActivity = nil;
       [self.commandDelegate sendPluginResult: pluginResult callbackId: command.callbackId];
     }
   }];
+}
+
+- (void)getLastNativeInitDebug:(CDVInvokedUrlCommand*)command
+{
+  NSDictionary *debugInfo = [BranchSDK lastNativeInitDebug];
+  CDVPluginResult* pluginResult = nil;
+
+  if (debugInfo != nil && [debugInfo count] > 0) {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:debugInfo];
+  } else {
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:FALSE];
+  }
+
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setRequestMetadata:(CDVInvokedUrlCommand*)command

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -5,6 +5,7 @@ static NSURL *branchPendingOpenURL = nil;
 static NSDictionary *branchPendingOpenURLOptions = nil;
 static NSUserActivity *branchPendingUserActivity = nil;
 static NSDictionary *branchLastNativeInitDebug = nil;
+static NSMutableDictionary *branchLifecycleDebug = nil;
 
 @interface BranchSDK()
 
@@ -25,6 +26,56 @@ static NSDictionary *branchLastNativeInitDebug = nil;
 + (void)setPendingUserActivity:(NSUserActivity *)userActivity
 {
   branchPendingUserActivity = userActivity;
+}
+
++ (NSMutableDictionary *)lifecycleDebug
+{
+  if (branchLifecycleDebug == nil) {
+    branchLifecycleDebug = [NSMutableDictionary dictionary];
+  }
+  return branchLifecycleDebug;
+}
+
++ (void)noteOpenURL:(NSURL *)url options:(NSDictionary *)options
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawOpenURL"];
+  if (url != nil) {
+    [debug setObject:[url absoluteString] forKey:@"lastOpenURL"];
+  }
+  if (options != nil) {
+    [debug setObject:options forKey:@"lastOpenURLOptions"];
+  }
+}
+
++ (void)noteUserActivity:(NSUserActivity *)userActivity
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawContinueUserActivity"];
+  if (userActivity != nil) {
+    [debug setObject:userActivity.activityType ?: @"" forKey:@"lastUserActivityType"];
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil) {
+      [debug setObject:[userActivity.webpageURL absoluteString] forKey:@"lastUserActivityWebpageURL"];
+    }
+  }
+}
+
++ (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
+  [debug setObject:@YES forKey:@"sawDidFinishLaunchingWithOptions"];
+  if (launchOptions != nil) {
+    [debug setObject:[launchOptions allKeys] forKey:@"launchOptionsKeys"];
+    NSURL *launchURL = [launchOptions objectForKey:UIApplicationLaunchOptionsURLKey];
+    if (launchURL != nil) {
+      [debug setObject:[launchURL absoluteString] forKey:@"launchOptionsURL"];
+    }
+    NSDictionary *userActivityDictionary =
+      [launchOptions objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey];
+    if (userActivityDictionary != nil) {
+      [debug setObject:[userActivityDictionary allKeys] forKey:@"launchUserActivityKeys"];
+    }
+  }
 }
 
 + (NSURL *)pendingOpenURL
@@ -166,6 +217,7 @@ static NSDictionary *branchLastNativeInitDebug = nil;
       [preInitDebug setObject:[pendingUserActivity.webpageURL absoluteString] forKey:@"pendingWebpageURL"];
     }
   }
+  [preInitDebug addEntriesFromDictionary:[BranchSDK lifecycleDebug]];
   [BranchSDK setLastNativeInitDebug:preInitDebug];
 
   [[Branch getInstance] initSessionWithLaunchOptions:nil andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -4,6 +4,7 @@ NSString * const pluginVersion = @"6.6.1";
 static NSURL *branchPendingOpenURL = nil;
 static NSDictionary *branchPendingOpenURLOptions = nil;
 static NSUserActivity *branchPendingUserActivity = nil;
+static NSDictionary *branchPendingLaunchOptions = nil;
 static NSDictionary *branchLastNativeInitDebug = nil;
 static NSMutableDictionary *branchLifecycleDebug = nil;
 
@@ -64,6 +65,7 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
 {
   NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
   [debug setObject:@YES forKey:@"sawDidFinishLaunchingWithOptions"];
+  branchPendingLaunchOptions = launchOptions;
   if (launchOptions != nil) {
     [debug setObject:[launchOptions allKeys] forKey:@"launchOptionsKeys"];
     NSURL *launchURL = [launchOptions objectForKey:UIApplicationLaunchOptionsURLKey];
@@ -93,11 +95,17 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   return branchPendingUserActivity;
 }
 
++ (NSDictionary *)pendingLaunchOptions
+{
+  return branchPendingLaunchOptions;
+}
+
 + (void)clearPendingLaunchContext
 {
   branchPendingOpenURL = nil;
   branchPendingOpenURLOptions = nil;
   branchPendingUserActivity = nil;
+  branchPendingLaunchOptions = nil;
 }
 
 + (void)setLastNativeInitDebug:(NSDictionary *)debugInfo
@@ -196,6 +204,7 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   NSUserActivity *pendingUserActivity = [BranchSDK pendingUserActivity];
   NSURL *pendingOpenURL = [BranchSDK pendingOpenURL];
   NSDictionary *pendingOpenURLOptions = [BranchSDK pendingOpenURLOptions];
+  NSDictionary *pendingLaunchOptions = [BranchSDK pendingLaunchOptions];
 
   if (pendingUserActivity != nil) {
     [[Branch getInstance] continueUserActivity:pendingUserActivity];
@@ -208,8 +217,12 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   [preInitDebug setObject:pluginVersion forKey:@"pluginVersion"];
   [preInitDebug setObject:[NSNumber numberWithBool:(pendingUserActivity != nil)] forKey:@"hadPendingUserActivity"];
   [preInitDebug setObject:[NSNumber numberWithBool:(pendingOpenURL != nil)] forKey:@"hadPendingOpenURL"];
+  [preInitDebug setObject:[NSNumber numberWithBool:(pendingLaunchOptions != nil)] forKey:@"hadPendingLaunchOptions"];
   if (pendingOpenURL != nil) {
     [preInitDebug setObject:[pendingOpenURL absoluteString] forKey:@"pendingOpenURL"];
+  }
+  if (pendingLaunchOptions != nil) {
+    [preInitDebug setObject:[pendingLaunchOptions allKeys] forKey:@"pendingLaunchOptionsKeys"];
   }
   if (pendingUserActivity != nil) {
     [preInitDebug setObject:pendingUserActivity.activityType ?: @"" forKey:@"pendingUserActivityType"];
@@ -220,7 +233,7 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   [preInitDebug addEntriesFromDictionary:[BranchSDK lifecycleDebug]];
   [BranchSDK setLastNativeInitDebug:preInitDebug];
 
-  [[Branch getInstance] initSessionWithLaunchOptions:nil andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+  [[Branch getInstance] initSessionWithLaunchOptions:pendingLaunchOptions andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
     [BranchSDK clearPendingLaunchContext];
 
     NSMutableDictionary *nativeDebug = [NSMutableDictionary dictionaryWithDictionary:[BranchSDK lastNativeInitDebug] ?: @{}];

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -1,6 +1,9 @@
 #import "BranchSDK.h"
 
 NSString * const pluginVersion = @"6.6.1";
+static NSURL *branchPendingOpenURL = nil;
+static NSDictionary *branchPendingOpenURLOptions = nil;
+static NSUserActivity *branchPendingUserActivity = nil;
 
 @interface BranchSDK()
 
@@ -11,6 +14,39 @@ NSString * const pluginVersion = @"6.6.1";
 @end
 
 @implementation BranchSDK
+
++ (void)setPendingOpenURL:(NSURL *)url options:(NSDictionary *)options
+{
+  branchPendingOpenURL = url;
+  branchPendingOpenURLOptions = options;
+}
+
++ (void)setPendingUserActivity:(NSUserActivity *)userActivity
+{
+  branchPendingUserActivity = userActivity;
+}
+
++ (NSURL *)pendingOpenURL
+{
+  return branchPendingOpenURL;
+}
+
++ (NSDictionary *)pendingOpenURLOptions
+{
+  return branchPendingOpenURLOptions;
+}
+
++ (NSUserActivity *)pendingUserActivity
+{
+  return branchPendingUserActivity;
+}
+
++ (void)clearPendingLaunchContext
+{
+  branchPendingOpenURL = nil;
+  branchPendingOpenURLOptions = nil;
+  branchPendingUserActivity = nil;
+}
 
 - (void)pluginInitialize
 {
@@ -94,7 +130,20 @@ NSString * const pluginVersion = @"6.6.1";
 - (void)initSession:(CDVInvokedUrlCommand*)command
 {
   [[Branch getInstance] registerPluginName:@"CordovaIonic" version:pluginVersion];
+
+  NSUserActivity *pendingUserActivity = [BranchSDK pendingUserActivity];
+  NSURL *pendingOpenURL = [BranchSDK pendingOpenURL];
+  NSDictionary *pendingOpenURLOptions = [BranchSDK pendingOpenURLOptions];
+
+  if (pendingUserActivity != nil) {
+    [[Branch getInstance] continueUserActivity:pendingUserActivity];
+  } else if (pendingOpenURL != nil) {
+    NSDictionary *openOptions = pendingOpenURLOptions ? pendingOpenURLOptions : @{};
+    [[Branch getInstance] application:[UIApplication sharedApplication] openURL:pendingOpenURL options:openOptions];
+  }
+
   [[Branch getInstance] initSessionWithLaunchOptions:nil andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+    [BranchSDK clearPendingLaunchContext];
 
     NSString *resultString = nil;
     CDVPluginResult *pluginResult = nil;

--- a/src/ios/BranchSDK.m
+++ b/src/ios/BranchSDK.m
@@ -5,8 +5,6 @@ static NSURL *branchPendingOpenURL = nil;
 static NSDictionary *branchPendingOpenURLOptions = nil;
 static NSUserActivity *branchPendingUserActivity = nil;
 static NSDictionary *branchPendingLaunchOptions = nil;
-static NSDictionary *branchLastNativeInitDebug = nil;
-static NSMutableDictionary *branchLifecycleDebug = nil;
 
 @interface BranchSDK()
 
@@ -29,46 +27,19 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   branchPendingUserActivity = userActivity;
 }
 
-+ (NSMutableDictionary *)lifecycleDebug
-{
-  if (branchLifecycleDebug == nil) {
-    branchLifecycleDebug = [NSMutableDictionary dictionary];
-  }
-  return branchLifecycleDebug;
-}
-
 + (void)noteOpenURL:(NSURL *)url options:(NSDictionary *)options
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawOpenURL"];
-  if (url != nil) {
-    [debug setObject:[url absoluteString] forKey:@"lastOpenURL"];
-  }
-  if (options != nil) {
-    [debug setObject:options forKey:@"lastOpenURLOptions"];
-  }
+  [BranchSDK setPendingOpenURL:url options:options];
 }
 
 + (void)noteUserActivity:(NSUserActivity *)userActivity
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawContinueUserActivity"];
-  if (userActivity != nil) {
-    [debug setObject:userActivity.activityType ?: @"" forKey:@"lastUserActivityType"];
-    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil) {
-      [debug setObject:[userActivity.webpageURL absoluteString] forKey:@"lastUserActivityWebpageURL"];
-    }
-  }
+  [BranchSDK setPendingUserActivity:userActivity];
 }
 
 + (void)noteSceneWillConnectWithURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
                              userActivities:(NSSet<NSUserActivity *> *)userActivities
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawSceneWillConnect"];
-  [debug setObject:@([URLContexts count]) forKey:@"sceneURLContextCount"];
-  [debug setObject:@([userActivities count]) forKey:@"sceneUserActivityCount"];
-
   UIOpenURLContext *context = [URLContexts allObjects].firstObject;
   if (context != nil) {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
@@ -94,10 +65,6 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
 
 + (void)noteSceneOpenURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawSceneOpenURLContexts"];
-  [debug setObject:@([URLContexts count]) forKey:@"sceneOpenURLContextCount"];
-
   UIOpenURLContext *context = [URLContexts allObjects].firstObject;
   if (context != nil) {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
@@ -117,29 +84,12 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
 
 + (void)noteSceneUserActivity:(NSUserActivity *)userActivity
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawSceneContinueUserActivity"];
   [BranchSDK noteUserActivity:userActivity];
-  [BranchSDK setPendingUserActivity:userActivity];
 }
 
 + (void)noteDidFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  NSMutableDictionary *debug = [BranchSDK lifecycleDebug];
-  [debug setObject:@YES forKey:@"sawDidFinishLaunchingWithOptions"];
   branchPendingLaunchOptions = launchOptions;
-  if (launchOptions != nil) {
-    [debug setObject:[launchOptions allKeys] forKey:@"launchOptionsKeys"];
-    NSURL *launchURL = [launchOptions objectForKey:UIApplicationLaunchOptionsURLKey];
-    if (launchURL != nil) {
-      [debug setObject:[launchURL absoluteString] forKey:@"launchOptionsURL"];
-    }
-    NSDictionary *userActivityDictionary =
-      [launchOptions objectForKey:UIApplicationLaunchOptionsUserActivityDictionaryKey];
-    if (userActivityDictionary != nil) {
-      [debug setObject:[userActivityDictionary allKeys] forKey:@"launchUserActivityKeys"];
-    }
-  }
 }
 
 + (NSURL *)pendingOpenURL
@@ -168,16 +118,6 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
   branchPendingOpenURLOptions = nil;
   branchPendingUserActivity = nil;
   branchPendingLaunchOptions = nil;
-}
-
-+ (void)setLastNativeInitDebug:(NSDictionary *)debugInfo
-{
-  branchLastNativeInitDebug = debugInfo;
-}
-
-+ (NSDictionary *)lastNativeInitDebug
-{
-  return branchLastNativeInitDebug;
 }
 
 - (void)pluginInitialize
@@ -303,39 +243,8 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
     [[Branch getInstance] application:[UIApplication sharedApplication] openURL:pendingOpenURL options:openOptions];
   }
 
-  NSMutableDictionary *preInitDebug = [NSMutableDictionary dictionary];
-  [preInitDebug setObject:pluginVersion forKey:@"pluginVersion"];
-  [preInitDebug setObject:[NSNumber numberWithBool:(pendingUserActivity != nil)] forKey:@"hadPendingUserActivity"];
-  [preInitDebug setObject:[NSNumber numberWithBool:(pendingOpenURL != nil)] forKey:@"hadPendingOpenURL"];
-  [preInitDebug setObject:[NSNumber numberWithBool:(pendingLaunchOptions != nil)] forKey:@"hadPendingLaunchOptions"];
-  if (pendingOpenURL != nil) {
-    [preInitDebug setObject:[pendingOpenURL absoluteString] forKey:@"pendingOpenURL"];
-  }
-  if (pendingLaunchOptions != nil) {
-    [preInitDebug setObject:[pendingLaunchOptions allKeys] forKey:@"pendingLaunchOptionsKeys"];
-  }
-  if (pendingUserActivity != nil) {
-    [preInitDebug setObject:pendingUserActivity.activityType ?: @"" forKey:@"pendingUserActivityType"];
-    if ([pendingUserActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && pendingUserActivity.webpageURL != nil) {
-      [preInitDebug setObject:[pendingUserActivity.webpageURL absoluteString] forKey:@"pendingWebpageURL"];
-    }
-  }
-  [preInitDebug addEntriesFromDictionary:[BranchSDK lifecycleDebug]];
-  [BranchSDK setLastNativeInitDebug:preInitDebug];
-
   [[Branch getInstance] initSessionWithLaunchOptions:pendingLaunchOptions andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
     [BranchSDK clearPendingLaunchContext];
-
-    NSMutableDictionary *nativeDebug = [NSMutableDictionary dictionaryWithDictionary:[BranchSDK lastNativeInitDebug] ?: @{}];
-    [nativeDebug setObject:[NSNumber numberWithBool:(params != nil)] forKey:@"nativeCallbackHasParams"];
-    [nativeDebug setObject:[NSNumber numberWithUnsignedInteger:(params ? [params count] : 0)] forKey:@"nativeParamsCount"];
-    if (params != nil) {
-      [nativeDebug setObject:params forKey:@"nativeParams"];
-    }
-    if (error != nil) {
-      [nativeDebug setObject:[error localizedDescription] ?: @"Unknown Branch init error" forKey:@"nativeError"];
-    }
-    [BranchSDK setLastNativeInitDebug:nativeDebug];
 
     NSString *resultString = nil;
     CDVPluginResult *pluginResult = nil;
@@ -374,20 +283,6 @@ static NSMutableDictionary *branchLifecycleDebug = nil;
       [self.commandDelegate sendPluginResult: pluginResult callbackId: command.callbackId];
     }
   }];
-}
-
-- (void)getLastNativeInitDebug:(CDVInvokedUrlCommand*)command
-{
-  NSDictionary *debugInfo = [BranchSDK lastNativeInitDebug];
-  CDVPluginResult* pluginResult = nil;
-
-  if (debugInfo != nil && [debugInfo count] > 0) {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:debugInfo];
-  } else {
-    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:FALSE];
-  }
-
-  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setRequestMetadata:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
This change updates the iOS Branch integration so deep-link and attribution data is captured earlier in the app lifecycle and then replayed when initSession runs. It adds support for both app delegate and scene delegate entry points, preserves pending launch context across Cordova/Ionic startup timing, and broadens URL handling to cover the richer Cordova openURL notification path.
The result should be more reliable Branch initialization and deep-link attribution on iOS, especially for cold starts and scene-based lifecycle flows, without keeping the temporary native debug surface that was used during investigation.
