### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/infra
+* @BranchMetrics/sdk-maintainers


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/infra) as part of the service-catalogue rollout.