### PR TITLE
fix(ios): resolve entitlements folder name via xcodeproj path, not projectName

### DIFF
--- a/src/scripts/ios/updateAssociatedDomains.js
+++ b/src/scripts/ios/updateAssociatedDomains.js
@@ -32,6 +32,13 @@
   // get the xcode .entitlements and provisioning profile .plist
   function getEntitlementFiles(preferences) {
     const files = [];
+    // Since cordova-ios 8.0.0 the generated Xcode project/target is always named "App",
+    // regardless of the <name> set in config.xml, so derive the real folder name from the
+    // already-resolved xcodeproj path instead of preferences.projectName.
+    const projectFolderName = path.basename(
+      path.dirname(preferences.iosProjectModule.xcode.filepath),
+      ".xcodeproj"
+    );
 
     for (let i = 0; i < BUILD_TYPES.length; i++) {
       const buildType = BUILD_TYPES[i];
@@ -39,7 +46,7 @@
         preferences.projectRoot,
         "platforms",
         "ios",
-        preferences.projectName,
+        projectFolderName,
         `Entitlements-${buildType}.plist`
       );
       files.push(plist);


### PR DESCRIPTION
## Summary

Since cordova-ios 8.0.0, the generated Xcode project/target is always named `App`, regardless of the `<name>` set in `config.xml`. `getEntitlementFiles()` in `src/scripts/ios/updateAssociatedDomains.js` still builds the `Entitlements-{Debug,Release}.plist` path from the raw `config.xml` `projectName`, so on cordova-ios 8+ projects it silently writes entitlements into a stray, never-referenced folder (e.g. `platforms/ios/MyApp/Entitlements-Debug.plist`) instead of the real project folder actually used by the Xcode build (`platforms/ios/App/Entitlements-Debug.plist`). Associated domains configured via the `link-domain` preference are never applied to the actual build in that case — no error is raised, it just silently doesn't work.

## Fix

Derive the folder name from `preferences.iosProjectModule.xcode.filepath` instead of `preferences.projectName`. This is already resolved correctly elsewhere in the plugin (`src/scripts/npm/processConfigXml.js`'s `getProjectModuleGlob`) via a glob over `platforms/ios/*.xcodeproj/project.pbxproj`, so this reuses that existing, already-correct resolution rather than introducing a new one.

## Test plan

- Verified on a cordova-ios 8.1.1 project where `config.xml`'s `<name>` differs from `App`: before the fix, `platforms/ios/<config-name>/Entitlements-*.plist` was created and the real `platforms/ios/App/Entitlements-*.plist` was left untouched (no associated domains applied to the build); after the fix, entitlements are correctly written to `platforms/ios/App/Entitlements-*.plist`.
